### PR TITLE
Cli config aliases

### DIFF
--- a/lib/cli-config.js
+++ b/lib/cli-config.js
@@ -5,7 +5,7 @@ const { applyOptions } = require('./commands/common-options');
 // Add support for custom configs
 // TODO: Perform some validation of the config
 let cliConfig = {};
-const configPath = findUp.sync(['.stripesrc.js', '.stripesrc.json', '.stripesrc']);
+const configPath = findUp.sync(['.stripesclirc.js', '.stripesclirc.json', '.stripesclirc']);
 if (configPath) {
   if (configPath.endsWith('.js')) {
     cliConfig = require(configPath); // eslint-disable-line
@@ -57,4 +57,5 @@ module.exports = {
   commandDirOptions,
   configPath,
   plugins: cliConfig.plugins,
+  aliases: cliConfig.aliases,
 };

--- a/lib/commands/status.js
+++ b/lib/commands/status.js
@@ -13,7 +13,7 @@ function statusCommand(argv) {
   console.log(`  module: ${context.moduleName ? context.moduleName : ''}`);
   console.log(`  cli install: ${context.isGlobalCli ? 'global' : 'local'}`);
   console.log(`  stripes-core: ${context.isLocalCoreAvailable ? 'local' : 'cli'} dependency`);
-  console.log(`  .stripesrc: ${configPath || '(none found)'}`);
+  console.log(`  .stripesclirc: ${configPath || '(none found)'}`);
 
   const storage = new PlatformStorage();
   console.log(`  storage path: ${storage.getStoragePath()}`);

--- a/lib/platform/platform-config.js
+++ b/lib/platform/platform-config.js
@@ -11,15 +11,12 @@ const defaultConfig = {
   },
   modules: {
   },
-  aliases: {
-  },
 };
 
 const emptyConfig = {
   okapi: {},
   config: {},
   modules: {},
-  aliases: {},
 };
 
 // Merge two stripes configurations
@@ -29,7 +26,6 @@ function mergeConfig(base, extend) {
     okapi: Object.assign({}, base.okapi, extend.okapi),
     config: Object.assign({}, base.config, extend.config),
     modules: Object.assign({}, base.modules, extend.modules),
-    aliases: Object.assign({}, base.aliases, extend.aliases),
   };
 }
 

--- a/lib/platform/stripes-platform.js
+++ b/lib/platform/stripes-platform.js
@@ -14,7 +14,7 @@ module.exports = class StripesPlatform {
       this.config = defaultConfig;
     }
     this.isAppContext = context.type === 'app';
-    // Assign aliases defined in .stripesrc file
+    // Assign aliases defined in .stripesclirc file
     // TODO: Pass this in?
     this.aliases = aliases || {};
   }

--- a/lib/platform/stripes-platform.js
+++ b/lib/platform/stripes-platform.js
@@ -2,7 +2,7 @@ const path = require('path');
 const PlatformStorage = require('./platform-storage');
 const { defaultConfig, emptyConfig, mergeConfig } = require('./platform-config');
 const { validateAliases } = require('./alias-validation');
-
+const { aliases } = require('../cli-config');
 
 module.exports = class StripesPlatform {
   constructor(stripesConfigFile, context) {
@@ -14,10 +14,9 @@ module.exports = class StripesPlatform {
       this.config = defaultConfig;
     }
     this.isAppContext = context.type === 'app';
-
-    if (this.config.aliases) {
-      this.config.aliases = validateAliases(this.config.aliases);
-    }
+    // Assign aliases defined in .stripesrc file
+    // TODO: Pass this in?
+    this.aliases = aliases || {};
   }
 
   // Adds self to the create a virtual platform
@@ -28,7 +27,7 @@ module.exports = class StripesPlatform {
     const modules = {};
     modules[moduleName] = {};
     this.config = mergeConfig(this.config, { modules });
-    this.config.aliases[moduleName] = path.resolve();
+    this.aliases[moduleName] = path.resolve();
   }
 
   // Adds previously saved virtual platform aliases to the config
@@ -38,7 +37,7 @@ module.exports = class StripesPlatform {
     const moduleNames = Object.getOwnPropertyNames(allAliases);
     for (const moduleName of moduleNames) {
       this.config.modules[moduleName] = {};
-      this.config.aliases[moduleName] = allAliases[moduleName];
+      this.aliases[moduleName] = allAliases[moduleName];
     }
   }
 
@@ -63,6 +62,6 @@ module.exports = class StripesPlatform {
   }
 
   getAliases() {
-    return this.config.aliases;
+    return validateAliases(this.aliases);
   }
 };


### PR DESCRIPTION
Consolidate alias configuration into new CLI config file.  This keeps CLI concerns separate from tenant-specific stripes configuration.