### PR TITLE
Lock karma-webpack to 2.0.6 to resolve 404's running unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "karma-chrome-launcher": "^2.2.0",
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
-    "karma-webpack": "^2.0.6",
+    "karma-webpack": "2.0.6",
     "kopy": "^8.2.3",
     "mocha": "^4.0.1",
     "resolve": "^1.4.0",


### PR DESCRIPTION
Fixes 404's running Karma unit tests discussed in STRIPES-494.

The cause appears to a defect found in versions of `karma-webpack` greater than 2.0.6.
https://github.com/webpack-contrib/karma-webpack/issues/289

The 404's may be related to `/_karma_webpack_/`paths used for the in-memory file system. Comparing the verbose webpack output of my NPM-installed CLI with that of my Yarn-installed CLI, I came across a discrepancy in `PublicPath` with the Yarn version was pointing to a nonexistent directory in the temporary `/var/folders/...` path on disk.

As a global NPM install, the existing package-lock.json is respected which happens to have karma-webpack already set at 2.0.6.  Once we started using Stripes CLI with ui-eholdings via Yarn, the latest version of karma-webpack was pulled in surfacing this error.

