### PR TITLE
STCLI-16 karma options

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -27,7 +27,7 @@ function testCommand(argv) {
   if (argv.type === 'unit') {
     console.log('Starting unit tests...');
     const webpackConfig = getStripesWebpackConfig(platform.getStripesConfig(), Object.assign({}, argv, { webpackOverrides }));
-    runUnitTests(webpackConfig);
+    runUnitTests(webpackConfig, argv.karma);
   } else {
     console.log('Waiting for webpack to build...');
     stripes.serve(platform.getStripesConfig(), Object.assign({}, argv, { webpackOverrides }))
@@ -62,6 +62,11 @@ module.exports = {
         choices: ['e2e', 'unit'],
         default: 'e2e',
       })
+      .option('karma', {
+        describe: 'Options passed to Karma using dot-notation and camelCase: --karma.browsers=Chrome --karma.singleRun',
+      })
+      .option('karma.browsers', { type: 'array', hidden: true }) // defined but hidden so yargs will parse as an array
+      .option('karma.reporters', { type: 'array', hidden: true })
       .example('$0 test --run=demo', 'Serve app and run it\'s demo.js integration tests')
       .example('$0 test --type=unit --hasAllPerms', 'Run unit tests for the current app module');
     return applyOptions(yargs, Object.assign({}, serverOptions, stripesConfigOptions));

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -9,7 +9,7 @@ const { applyOptions, serverOptions, stripesConfigOptions } = importLazy('./comm
 const { cliAliases, cliResolve } = importLazy('../webpack-common');
 const getStripesWebpackConfig = importLazy('../test/webpack-config');
 
-function testCommand(argv) {
+function testCommand(argv, plugin) {
   if (context.type !== 'app') {
     console.log('Tests are only supported within an app context.');
     return;
@@ -23,6 +23,10 @@ function testCommand(argv) {
   platform.applyVirtualAppPlatform(context.moduleName);
   platform.applyCommandOptions(argv);
   webpackOverrides.push(cliAliases(platform.getAliases()));
+
+  if (plugin && plugin.beforeBuild) {
+    webpackOverrides.push(plugin.beforeBuild(argv));
+  }
 
   if (argv.type === 'unit') {
     console.log('Starting unit tests...');

--- a/lib/test/unit.js
+++ b/lib/test/unit.js
@@ -5,7 +5,7 @@ const Karma = require('karma').Server;
 const cwd = path.resolve();
 
 // Runs the specified integration tests
-module.exports = function runUnitTests(webpackConfig) {
+module.exports = function runUnitTests(webpackConfig, karmaOptions) {
   // TODO: Standardize on test folder, 'test' vs 'tests'
   const testIndex = path.join(cwd, 'tests', 'index.js');
   const preprocessors = {};
@@ -44,6 +44,11 @@ module.exports = function runUnitTests(webpackConfig) {
 
   if (fs.existsSync(path.join(cwd, 'karma.conf.js'))) {
     karmaConfig.configFile = path.join(cwd, 'karma.conf.js');
+  }
+
+  // Apply user supplied --karma options to configuration
+  if (karmaOptions) {
+    Object.assign(karmaConfig, karmaOptions);
   }
 
   const karma = new Karma(karmaConfig, (exitCode) => {

--- a/lib/test/unit.js
+++ b/lib/test/unit.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const Karma = require('karma').Server;
+const { Server, config } = require('karma');
 
 const cwd = path.resolve();
 
@@ -11,7 +11,7 @@ module.exports = function runUnitTests(webpackConfig, karmaOptions) {
   const preprocessors = {};
   preprocessors[`${testIndex}`] = ['webpack'];
 
-  const karmaConfig = {
+  let karmaConfig = {
     frameworks: ['mocha'],
     reporters: ['mocha'],
     port: 9876,
@@ -39,19 +39,31 @@ module.exports = function runUnitTests(webpackConfig, karmaOptions) {
       'karma-mocha',
       'karma-webpack',
       'karma-mocha-reporter',
+      'karma-coverage',
     ],
   };
 
-  if (fs.existsSync(path.join(cwd, 'karma.conf.js'))) {
-    karmaConfig.configFile = path.join(cwd, 'karma.conf.js');
-  }
-
   // Apply user supplied --karma options to configuration
+  // Added now so they will be available within app-supplied config function
   if (karmaOptions) {
     Object.assign(karmaConfig, karmaOptions);
   }
 
-  const karma = new Karma(karmaConfig, (exitCode) => {
+  // Use Karma's parser to prep the base config
+  karmaConfig = config.parseConfig(undefined, karmaConfig);
+
+  // Check for an app-supplied Karma config and apply it
+  if (fs.existsSync(path.join(cwd, 'karma.conf.js'))) {
+    const appKarmaConfig = require(path.join(cwd, 'karma.conf.js'));  // eslint-disable-line
+    appKarmaConfig(karmaConfig);
+
+    // Reapply user options so they take precedence
+    if (karmaOptions) {
+      Object.assign(karmaConfig, karmaOptions);
+    }
+  }
+
+  const karma = new Server(karmaConfig, (exitCode) => {
     console.log(`Karma exited with ${exitCode}`);
   });
   karma.start();

--- a/package-lock.json
+++ b/package-lock.json
@@ -344,6 +344,11 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.48.tgz",
       "integrity": "sha512-LLlXafM3BD52MH056tHxTXO8JFCnpJJQkdzIU3+m8ew+CXJY/5zIXgDNb4TK/QFvlI8QexLS5tL+sE0Qhegr1w=="
     },
+    "abbrev": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
+    },
     "abstract-leveldown": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
@@ -2948,6 +2953,15 @@
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
     },
+    "dateformat": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+      "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
+      "requires": {
+        "get-stdin": "4.0.1",
+        "meow": "3.7.0"
+      }
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -2999,8 +3013,7 @@
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "defaults": {
       "version": "1.0.3",
@@ -3706,6 +3719,34 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "escodegen": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+      "requires": {
+        "esprima": "2.7.3",
+        "estraverse": "1.9.3",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+          "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
+        },
+        "source-map": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+          "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+          "optional": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
+      }
     },
     "escope": {
       "version": "3.6.0",
@@ -4450,8 +4491,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fastparse": {
       "version": "1.1.1",
@@ -5710,6 +5750,63 @@
         "duplexer": "0.1.1"
       }
     },
+    "handlebars": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+      "requires": {
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        },
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        },
+        "uglify-js": {
+          "version": "2.8.29",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+          "optional": true,
+          "requires": {
+            "source-map": "0.5.7",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "optional": true
+            }
+          }
+        },
+        "yargs": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+          "optional": true,
+          "requires": {
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
+            "window-size": "0.1.0"
+          }
+        }
+      }
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -6506,6 +6603,69 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
+    "istanbul": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
+      "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
+      "requires": {
+        "abbrev": "1.0.9",
+        "async": "1.5.2",
+        "escodegen": "1.8.1",
+        "esprima": "2.7.3",
+        "glob": "5.0.15",
+        "handlebars": "4.0.11",
+        "js-yaml": "3.7.0",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "once": "1.4.0",
+        "resolve": "1.1.7",
+        "supports-color": "3.2.3",
+        "which": "1.3.0",
+        "wordwrap": "1.0.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        },
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+        },
+        "resolve": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "requires": {
+            "has-flag": "1.0.0"
+          }
+        },
+        "wordwrap": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+        }
+      }
+    },
     "js-base64": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.0.tgz",
@@ -6707,6 +6867,30 @@
       "requires": {
         "fs-access": "1.0.1",
         "which": "1.3.0"
+      }
+    },
+    "karma-coverage": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/karma-coverage/-/karma-coverage-1.1.1.tgz",
+      "integrity": "sha1-Wv+LOc9plNwi3kyENix2ABtjfPY=",
+      "requires": {
+        "dateformat": "1.0.12",
+        "istanbul": "0.4.5",
+        "lodash": "3.10.1",
+        "minimatch": "3.0.4",
+        "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        }
       }
     },
     "karma-mocha": {
@@ -6936,7 +7120,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
       "requires": {
         "prelude-ls": "1.1.2",
         "type-check": "0.3.2"
@@ -7917,6 +8100,14 @@
       "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
       "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
     },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "requires": {
+        "abbrev": "1.0.9"
+      }
+    },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -8106,7 +8297,6 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true,
       "requires": {
         "deep-is": "0.1.3",
         "fast-levenshtein": "2.0.6",
@@ -8119,8 +8309,7 @@
         "wordwrap": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-          "dev": true
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
         }
       }
     },
@@ -10193,8 +10382,7 @@
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "prepend-http": {
       "version": "1.0.4",
@@ -12141,7 +12329,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
       "requires": {
         "prelude-ls": "1.1.2"
       }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "just-pascal-case": "^1.0.0",
     "karma": "^1.7.1",
     "karma-chrome-launcher": "^2.2.0",
+    "karma-coverage": "^1.1.1",
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
     "karma-webpack": "2.0.6",


### PR DESCRIPTION
New CLI `--karma` option enables karma-specific options to be passed on the command line using dot notation.  For example, `--karma.singleRun` and `--karma.browsers=Chrome`.

The CLI's plugin pattern has been extended to the `test` command providing the same beforeBuild webpack hook available to `serve` and `build`.  This allows for manipulation of the webpack config as necessary during tests.

Finally a correction to the karma config order has been made preventing the base karma configuration from inadvertently overriding values supplied by the app's karma config.