### PR TITLE
Apply proper exit code upon unit and e2e test failure

### DIFF
--- a/lib/test/integration.js
+++ b/lib/test/integration.js
@@ -40,5 +40,6 @@ module.exports = function runIntegrationTests(options) {
     .catch((err) => {
       console.error('Some tests failed or something went wrong while attempting to run the tests.');
       console.info(err);
+      process.exit(1);
     });
 };

--- a/lib/test/unit.js
+++ b/lib/test/unit.js
@@ -65,6 +65,7 @@ module.exports = function runUnitTests(webpackConfig, karmaOptions) {
 
   const karma = new Server(karmaConfig, (exitCode) => {
     console.log(`Karma exited with ${exitCode}`);
+    process.exit(exitCode);
   });
   karma.start();
 };


### PR DESCRIPTION
Probably should consolidate process.exits when introducing more robust error handling