### PR TITLE
STCLI-19 prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,20 +116,20 @@ Note: Builds intended for production should be made using a previously defined p
 
 ### `test` command (work in progress)
 
-Runs tests for an app in the APP context.  Right now `test` supports UI integration tests written for NightmareJS and preliminary support for unit tests run with Karma.
+Runs tests for an app in the APP context.
 
-Integration tests support a small subset of the options available in [ui-testing](https://github.com/folio-org/ui-testing).  This includes `--run`, `--host`, and `--port`.  Note: The `--run` option varies slightly from ui-testing in that it should be supplied with only a test script name (`--run=<script>`) and not include the app name as it does today (`--run=<app:script>`).
-
-Example:
-```
-stripescli test --run=demo --show
-```
-
-Unit tests currently depend on the app's own infrastructure to define the test harness that loads the app (work in progress).  The CLI will generate a webpack configuration for Karma similar to `build` and `serve` so no mocking of `stripes-config` is necessary.
+The `nightmare` sub-command supports UI integration tests written for NightmareJS.  The tests support a small subset of the options available in [ui-testing](https://github.com/folio-org/ui-testing).  This includes `--run`, `--host`, and `--port`.  Note: The `--run` option varies slightly from ui-testing in that it should be supplied with only a test script name (`--run=<script>`) and not include the app name as it does today (`--run=<app:script>`).
 
 Example:
 ```
-stripescli test --type=unit
+stripescli test nightmare --run=demo --show
+```
+
+The `karma` sub-command supports running an app's tests with Karma.  These tests currently depend on the app's own infrastructure to define the test harness that loads the app (work in progress).  The CLI will generate a webpack configuration for Karma similar to `build` and `serve` so no mocking of `stripes-config` is necessary.
+
+Example:
+```
+stripescli test karma
 ```
 
 ### `alias` command

--- a/lib/cli/config.js
+++ b/lib/cli/config.js
@@ -2,6 +2,11 @@ const findUp = require('find-up');
 const fs = require('fs');
 const { applyOptions } = require('../commands/common-options');
 
+// Maintain backwards compatibility for plugins referencing previous commands
+const pluginMap = {
+  karma: 'test', // previously "test --type=unit"
+};
+
 // Add support for custom configs
 // TODO: Perform some validation of the config
 let cliConfig = {};
@@ -22,7 +27,7 @@ function applyCommandPlugin(command, pathToFile, filename) {
 
   // TODO: Match against command name (currently checking filename)
   const commandName = filename.replace('.js', '');
-  const plugin = cliConfig.plugins[commandName];
+  const plugin = cliConfig.plugins[commandName] || cliConfig.plugins[pluginMap[commandName]];
 
   if (plugin) {
     // TODO: Validate options

--- a/lib/commands/alias.js
+++ b/lib/commands/alias.js
@@ -11,7 +11,7 @@ function listAliases(aliases) {
   } else {
     for (const name of aliasNames) {
       const alias = aliases[name];
-      console.log(`  ${name} --> ${alias.path} [${alias.type || 'other'}] [${alias.isValid ? 'valid' : 'ERROR'}]`);
+      console.log(`  ${name} --> ${alias.path} [${alias.type || 'other'}] [${alias.isValid ? 'valid' : 'ERROR'}] ${!alias.hasNodeModules ? '[missing node_modules]' : ''}`);
     }
   }
   return aliasNames.length;

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -4,7 +4,7 @@ const { mainHandler } = importLazy('../cli/main-handler');
 const stripes = importLazy('@folio/stripes-core/webpack/stripes-node-api');
 const StripesPlatform = importLazy('../platform/stripes-platform');
 const { applyOptions, serverOptions, okapiOptions, stripesConfigOptions, buildOptions } = importLazy('./common-options');
-const { emitLintWarnings, limitChunks } = importLazy('../webpack-common');
+const { processError, emitLintWarnings, limitChunks } = importLazy('../webpack-common');
 
 function serveCommand(argv, context) {
   // Default serve command to development env
@@ -35,7 +35,8 @@ function serveCommand(argv, context) {
   }
 
   console.log('Waiting for webpack to build...');
-  stripes.serve(platform.getStripesConfig(), Object.assign({}, argv, { webpackOverrides }));
+  stripes.serve(platform.getStripesConfig(), Object.assign({}, argv, { webpackOverrides }))
+    .catch(processError);
 }
 
 module.exports = {

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -21,12 +21,6 @@ module.exports = {
   builder: (yargs) => {
     yargs
       .commandDir('test', commandDirOptions)
-      .option('type <type>', {
-        describe: 'Type of tests to run',
-        type: 'string',
-        choices: ['e2e', 'unit'],
-        default: 'e2e',
-      })
       .example('$0 test nightmare --run=demo', 'Serve app and run it\'s demo.js Nightmare tests')
       .example('$0 test karma', 'Run Karma tests for the current app module');
     return applyOptions(yargs, Object.assign({}, serverOptions, okapiOptions, stripesConfigOptions));

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -1,45 +1,17 @@
 const importLazy = require('import-lazy')(require);
 
 const { mainHandler } = importLazy('../cli/main-handler');
-const stripes = importLazy('@folio/stripes-core/webpack/stripes-node-api');
-const runIntegrationTests = importLazy('../test/integration');
-const runUnitTests = importLazy('../test/unit');
-const StripesPlatform = importLazy('../platform/stripes-platform');
 const { applyOptions, serverOptions, okapiOptions, stripesConfigOptions } = importLazy('./common-options');
-const getStripesWebpackConfig = importLazy('../test/webpack-config');
+const nightmareCommand = importLazy('./test/nightmare').handler;
+const karmaCommand = importLazy('./test/karma').handler;
+const { commandDirOptions } = importLazy('../cli/config');
 
 function testCommand(argv, context) {
-  // Default test command to test env
-  if (!process.env.NODE_ENV) {
-    process.env.NODE_ENV = 'test';
-  }
-
-  if (context.type !== 'app') {
-    console.log('Tests are only supported within an app context.');
-    return;
-  }
-
-  // TODO: check options and prompt for tests if none are specified
-
-  const platform = new StripesPlatform(argv.configFile, context, argv);
-  const webpackOverrides = platform.getWebpackOverrides(context.isLocalCoreAvailable);
-
-  if (context.plugin && context.plugin.beforeBuild) {
-    webpackOverrides.push(context.plugin.beforeBuild(argv));
-  }
-
+  // Maintain backwards compatibility with original commands
   if (argv.type === 'unit') {
-    console.log('Starting unit tests...');
-    const webpackConfig = getStripesWebpackConfig(platform.getStripesConfig(), Object.assign({}, argv, { webpackOverrides }));
-    runUnitTests(webpackConfig, argv.karma);
+    karmaCommand(argv, context);
   } else {
-    console.log('Waiting for webpack to build...');
-    stripes.serve(platform.getStripesConfig(), Object.assign({}, argv, { webpackOverrides }))
-      .then((stats) => {
-        // TODO: Check for webpack errors before running tests
-        console.log('Starting integration tests...');
-        runIntegrationTests(argv); // TODO: then shutdown the server
-      });
+    nightmareCommand(argv, context);
   }
 }
 
@@ -48,31 +20,15 @@ module.exports = {
   describe: 'Run the current app module\'s tests',
   builder: (yargs) => {
     yargs
-      .positional('configFile', {
-        describe: 'File containing a Stripes tenant configuration',
-        type: 'string',
-      })
-      .option('run', {
-        describe: 'Name of the test script to run (e2e)',
-        type: 'string',
-      })
-      .option('show', {
-        describe: 'Show UI and dev tools while running tests (e2e)',
-        type: 'boolean',
-      })
+      .commandDir('test', commandDirOptions)
       .option('type <type>', {
         describe: 'Type of tests to run',
         type: 'string',
         choices: ['e2e', 'unit'],
         default: 'e2e',
       })
-      .option('karma', {
-        describe: 'Options passed to Karma using dot-notation and camelCase: --karma.browsers=Chrome --karma.singleRun',
-      })
-      .option('karma.browsers', { type: 'array', hidden: true }) // defined but hidden so yargs will parse as an array
-      .option('karma.reporters', { type: 'array', hidden: true })
-      .example('$0 test --run=demo', 'Serve app and run it\'s demo.js integration tests')
-      .example('$0 test --type=unit --hasAllPerms', 'Run unit tests for the current app module');
+      .example('$0 test nightmare --run=demo', 'Serve app and run it\'s demo.js Nightmare tests')
+      .example('$0 test karma', 'Run Karma tests for the current app module');
     return applyOptions(yargs, Object.assign({}, serverOptions, okapiOptions, stripesConfigOptions));
   },
   handler: mainHandler(testCommand),

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -16,7 +16,7 @@ function testCommand(argv, context) {
 }
 
 module.exports = {
-  command: 'test [configFile]',
+  command: 'test',
   describe: 'Run the current app module\'s tests',
   builder: (yargs) => {
     yargs

--- a/lib/commands/test/karma.js
+++ b/lib/commands/test/karma.js
@@ -1,0 +1,50 @@
+const importLazy = require('import-lazy')(require);
+
+const { mainHandler } = importLazy('../../cli/main-handler');
+const runUnitTests = importLazy('../../test/unit');
+const StripesPlatform = importLazy('../../platform/stripes-platform');
+const { applyOptions, serverOptions, okapiOptions, stripesConfigOptions } = importLazy('../common-options');
+const getStripesWebpackConfig = importLazy('../../test/webpack-config');
+
+function karmaCommand(argv, context) {
+  // Default test command to test env
+  if (!process.env.NODE_ENV) {
+    process.env.NODE_ENV = 'test';
+  }
+
+  if (context.type !== 'app') {
+    console.log('Tests are only supported within an app context.');
+    return;
+  }
+
+  const platform = new StripesPlatform(argv.configFile, context, argv);
+  const webpackOverrides = platform.getWebpackOverrides(context.isLocalCoreAvailable);
+
+  if (context.plugin && context.plugin.beforeBuild) {
+    webpackOverrides.push(context.plugin.beforeBuild(argv));
+  }
+
+  console.log('Starting Karma tests...');
+  const webpackConfig = getStripesWebpackConfig(platform.getStripesConfig(), Object.assign({}, argv, { webpackOverrides }));
+  runUnitTests(webpackConfig, argv.karma);
+}
+
+module.exports = {
+  command: 'karma [configFile]',
+  describe: 'Run the current app module\'s Karma tests',
+  builder: (yargs) => {
+    yargs
+      .positional('configFile', {
+        describe: 'File containing a Stripes tenant configuration',
+        type: 'string',
+      })
+      .option('karma', {
+        describe: 'Options passed to Karma using dot-notation and camelCase: --karma.browsers=Chrome --karma.singleRun',
+      })
+      .option('karma.browsers', { type: 'array', hidden: true }) // defined but hidden so yargs will parse as an array
+      .option('karma.reporters', { type: 'array', hidden: true })
+      .example('$0 test karma', 'Run tests with Karma for the current app module');
+    return applyOptions(yargs, Object.assign({}, serverOptions, okapiOptions, stripesConfigOptions));
+  },
+  handler: mainHandler(karmaCommand),
+};

--- a/lib/commands/test/nightmare.js
+++ b/lib/commands/test/nightmare.js
@@ -1,0 +1,59 @@
+const importLazy = require('import-lazy')(require);
+
+const { mainHandler } = importLazy('../../cli/main-handler');
+const stripes = importLazy('@folio/stripes-core/webpack/stripes-node-api');
+const runIntegrationTests = importLazy('../../test/integration');
+const StripesPlatform = importLazy('../../platform/stripes-platform');
+const { applyOptions, serverOptions, okapiOptions, stripesConfigOptions } = importLazy('../common-options');
+
+function nightmareCommand(argv, context) {
+  // Default test command to test env
+  if (!process.env.NODE_ENV) {
+    process.env.NODE_ENV = 'test';
+  }
+
+  if (context.type !== 'app') {
+    console.log('Tests are only supported within an app context.');
+    return;
+  }
+
+  // TODO: check options and prompt for tests if none are specified
+
+  const platform = new StripesPlatform(argv.configFile, context, argv);
+  const webpackOverrides = platform.getWebpackOverrides(context.isLocalCoreAvailable);
+
+  if (context.plugin && context.plugin.beforeBuild) {
+    webpackOverrides.push(context.plugin.beforeBuild(argv));
+  }
+
+  console.log('Waiting for webpack to build...');
+  stripes.serve(platform.getStripesConfig(), Object.assign({}, argv, { webpackOverrides }))
+    .then((stats) => {
+      // TODO: Check for webpack errors before running tests
+      console.log('Starting Nightmare tests...');
+      runIntegrationTests(argv); // TODO: then shutdown the server
+    });
+}
+
+module.exports = {
+  command: 'nightmare [configFile]',
+  describe: 'Run the current app module\'s Nightmare tests',
+  builder: (yargs) => {
+    yargs
+      .positional('configFile', {
+        describe: 'File containing a Stripes tenant configuration',
+        type: 'string',
+      })
+      .option('run', {
+        describe: 'Name of the test script to run',
+        type: 'string',
+      })
+      .option('show', {
+        describe: 'Show UI and dev tools while running tests',
+        type: 'boolean',
+      })
+      .example('$0 test nightmare --run=demo', 'Serve app and run it\'s demo.js Nightmare tests');
+    return applyOptions(yargs, Object.assign({}, serverOptions, okapiOptions, stripesConfigOptions));
+  },
+  handler: mainHandler(nightmareCommand),
+};

--- a/lib/platform/alias-service.js
+++ b/lib/platform/alias-service.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const fs = require('fs');
 const PlatformStorage = require('./platform-storage');
 const cliConfig = require('../cli/config');
 const AliasError = require('./alias-error');
@@ -70,6 +71,7 @@ module.exports = class AliasService {
     const packageJsonPath = path.join(absolutePath, '/package.json');
     let validationError = false;
     let stripesType;
+    let hasNodeModules;
 
     try {
       this.require.resolve(packageJsonPath);
@@ -86,6 +88,8 @@ module.exports = class AliasService {
         // Type is used later to determine which aliases need to be included in the modules section of a generated stripes.config
         stripesType = stripes.type;
       }
+
+      hasNodeModules = fs.existsSync(packageJsonPath.replace('package.json', 'node_modules'));
     }
 
     if (validationError && !parseOnly) {
@@ -96,6 +100,7 @@ module.exports = class AliasService {
       path: absolutePath,
       type: stripesType,
       isValid: !validationError,
+      hasNodeModules,
     };
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-cli",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Stripes Command Line Interface",
   "repository": "https://github.com/folio-org/stripes-cli",
   "publishConfig": {

--- a/test/platform/alias-service.spec.js
+++ b/test/platform/alias-service.spec.js
@@ -151,7 +151,7 @@ describe('The alias-service', function () {
 
     it('returns alias data', function () {
       const result = this.sut.validateAlias('moduleName', '../modulePath');
-      expect(result).to.have.keys('path', 'type', 'isValid');
+      expect(result).to.have.keys('path', 'type', 'isValid', 'hasNodeModules');
     });
 
     it('assigns stripes type', function () {


### PR DESCRIPTION
This breaks out separate testing workflows into their own commands, rather than switching on the  `--type` option.  Doing so will allow for more tailored CLI options and corresponding help for each.  It also aims to set a better pattern for adding other testing cases like the testing of `stripes-components`, etc. to be addressed in STCLI-19. 

Backwards compatibility remains for the time being with the former `--type` option still honored, but no longer present in readme or help.