### PR TITLE
STCLI-26 serve previous builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for stripes-cli
 
+## 1.1.0 (IN PROGRESS)
+
+* Add option to serve an existing build. STCLI-26
+
+
 ## [1.0.0](https://github.com/folio-org/stripes-cli/tree/v1.0.0) (2018-02-08)
 
 * Add support for passing options to Karma. STCLI-16
@@ -15,7 +20,8 @@
 * Apply proper exit code upon test failure. Fixes STCLI-17
 * Update webpack config for test with translations plugin. Fixes STCLI-21
 * Invoke CLI with `stripes` rather than `stripescli`. STCLI-11
-* Update new app templates to use React 16 and translations. STCLI-25
+* Update new app templates to use React 16. STCLI-25
+* Add translations to new app templates. STCLI-6
 
 
 ## 0.10.0 (2017-12-12 demo)

--- a/lib/commands/alias.js
+++ b/lib/commands/alias.js
@@ -2,7 +2,6 @@ const importLazy = require('import-lazy')(require);
 
 const { mainHandler } = importLazy('../cli/main-handler');
 const AliasService = importLazy('../platform/alias-service');
-const { configPath } = importLazy('../cli/config');
 
 function listAliases(aliases) {
   const aliasNames = Object.getOwnPropertyNames(aliases);

--- a/lib/commands/common-options.js
+++ b/lib/commands/common-options.js
@@ -16,7 +16,7 @@ module.exports.serverOptions = {
     group: 'Server Options:',
   },
   host: {
-    type: 'number',
+    type: 'string',
     describe: 'Development server host',
     default: 'localhost',
     group: 'Server Options:',

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -5,11 +5,20 @@ const stripes = importLazy('@folio/stripes-core/webpack/stripes-node-api');
 const StripesPlatform = importLazy('../platform/stripes-platform');
 const { applyOptions, serverOptions, okapiOptions, stripesConfigOptions, buildOptions } = importLazy('./common-options');
 const { processError, emitLintWarnings, limitChunks } = importLazy('../webpack-common');
+const server = importLazy('../server');
+
 
 function serveCommand(argv, context) {
   // Default serve command to development env
   if (!process.env.NODE_ENV) {
     process.env.NODE_ENV = 'development';
+  }
+
+  // When a directory is provided, there is nothing to build
+  if (argv.existingBuild) {
+    console.log('Serving an existing build...');
+    server.start(argv.existingBuild, argv);
+    return;
   }
 
   if (argv.prod) {
@@ -54,8 +63,14 @@ module.exports = {
         type: 'boolean',
         group: 'Stripes Options:',
       })
+      .option('existing-build', {
+        describe: 'Serve an existing build from the supplied directory',
+        type: 'string',
+        conflicts: 'configFile',
+      })
       .example('$0 serve --hasAllPerms', 'Serve an app (in app context) with permissions flag set for development')
-      .example('$0 serve stripes.config.js', 'Serve a platform defined by the supplied configuration');
+      .example('$0 serve stripes.config.js', 'Serve a platform defined by the supplied configuration')
+      .example('$0 serve --existing-build output', 'Serve a build previously created with "stripes build"');
     return applyOptions(yargs, Object.assign({}, serverOptions, okapiOptions, stripesConfigOptions, buildOptions));
   },
   handler: mainHandler(serveCommand),

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -21,6 +21,11 @@ function serveCommand(argv, context) {
     return;
   }
 
+  if (context.type !== 'app' || context.type !== 'platform') {
+    console.warn('Please check that you are in the correct directory!\n"serve" should be run from an app or platform context.\n');
+  }
+
+
   if (argv.prod) {
     console.log('Production config not yet implemented with serve');
     return;

--- a/lib/commands/test/nightmare.js
+++ b/lib/commands/test/nightmare.js
@@ -28,7 +28,7 @@ function nightmareCommand(argv, context) {
 
   console.log('Waiting for webpack to build...');
   stripes.serve(platform.getStripesConfig(), Object.assign({}, argv, { webpackOverrides }))
-    .then((stats) => {
+    .then(() => {
       // TODO: Check for webpack errors before running tests
       console.log('Starting Nightmare tests...');
       runNightmareTests(argv); // TODO: then shutdown the server

--- a/lib/okapi/permission-service.js
+++ b/lib/okapi/permission-service.js
@@ -22,7 +22,7 @@ module.exports = class PermissionService {
     return new Promise((resolve, reject) => {
       const packageJson = this._loadPackageJson();
       if (!packageJson) {
-        reject(`No package.json found in ${this.context.cwd}`);
+        reject(new Error(`No package.json found in ${this.context.cwd}`)); // TODO: Define CLI errors...
       }
       // Add new permission to "permissionSets" if not already there
       const found = packageJson.stripes.permissionSets.findIndex(perm => perm.permissionName === permission.permissionName);

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,11 +32,7 @@ function start(dir, options) {
   }
 
   const httpServer = path.join(__dirname, '..', 'node_modules', '.bin', 'http-server');
-  const serverArgs = [
-    dir,
-    '--port', options.port,
-    '--host', options.host,
-  ];
+  const serverArgs = [dir, '-p', options.port];
 
   runProcess(httpServer, serverArgs);
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,0 +1,46 @@
+const childProcess = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+// Creates a child process to run http-server so we can get all the nice output
+function runProcess(script, args) {
+  const options = {
+    cwd: path.resolve(),
+    stdio: 'inherit',
+  };
+
+  return new Promise((resolve, reject) => {
+    childProcess.spawn(script, args, options)
+      .on('exit', (error) => {
+        if (error) {
+          reject(error);
+        }
+        resolve();
+      });
+  });
+}
+
+function start(dir, options) {
+  // Perform some basic checks to ensure we have a directory with something to serve
+  if (!fs.existsSync(path.resolve(dir))) {
+    console.log(`Directory "${dir}" does not exist.`);
+    return;
+  }
+  if (!fs.existsSync(path.resolve(dir, 'index.html'))) {
+    console.log(`Directory "${dir}" does not contain an index.html.`);
+    return;
+  }
+
+  const httpServer = path.join(__dirname, '..', 'node_modules', '.bin', 'http-server');
+  const serverArgs = [
+    dir,
+    '--port', options.port,
+    '--host', options.host,
+  ];
+
+  runProcess(httpServer, serverArgs);
+}
+
+module.exports = {
+  start,
+};

--- a/lib/stripes-cli.js
+++ b/lib/stripes-cli.js
@@ -7,7 +7,6 @@ const packageJson = require('../package.json');
 const { isGlobal } = require('./cli/context');
 const AliasError = require('./platform/alias-error');
 const { yargsConfig, commandDirOptions } = require('./cli/config');
-const OkapiError = require('./okapi/okapi-error');
 
 process.title = 'stripes-cli';
 

--- a/lib/test/cli-test-module.js
+++ b/lib/test/cli-test-module.js
@@ -6,7 +6,7 @@
 //  - Simplified to support limited options in use by stripes-cli
 //  - Supports cwd of the ui-app module under test
 
-const Nightmare = require('@folio/ui-testing/xnightmare.js');
+const Nightmare = require('@folio/ui-testing/xnightmare.js'); // eslint-disable-line no-unused-vars, because we need this
 const config = require('@folio/ui-testing/folio-ui.config.js');
 const helpers = require('@folio/ui-testing/helpers.js');
 const path = require('path');

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "configstore": "^3.1.1",
     "debug": "^3.1.0",
     "find-up": "^2.1.0",
+    "http-server": "^0.11.1",
     "import-lazy": "^3.1.0",
     "inquirer": "^4.0.2",
     "just-kebab-case": "^1.0.0",
@@ -46,9 +47,9 @@
     "yargs": "^10.0.3"
   },
   "devDependencies": {
+    "@folio/eslint-config-stripes": "^1.1.0",
     "chai": "^4.1.2",
     "eslint": "^4.8.0",
-    "@folio/eslint-config-stripes": "^1.1.0",
     "sinon": "^4.1.4",
     "sinon-chai": "^2.14.0"
   }


### PR DESCRIPTION
Implements a simple http-server to serve up a previously created build

Given `stripes build stripes.config.js ouput` created a build.
Then `stripes serve --existing-build output` will serve it up.
