### PR TITLE
STCLI-18 apply alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.0 (IN PROGRESS)
 
 * Add option to serve an existing build. STCLI-26
+* When a config file with modules is provided, do not automatically apply aliases to module config. STCLI-18
 
 
 ## [1.0.0](https://github.com/folio-org/stripes-cli/tree/v1.0.0) (2018-02-08)

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ The platform that Stripes CLI uses is constructed in the following order:
 
 1. Base configuration:  When a file argument like `stripes.config.js` is provided, this will be used as the base.  Otherwise, the CLI will use its own internal defaults that contain no modules.
 
-2. Virtual configuration:  In the APP context, the CLI will apply the current app as a module and generate an alias for the app to be run in isolation.  In the PLATFORM context, the CLI will add modules for all aliases previously defined with the `alias` command.
+2. Virtual configuration:  In the APP context, the CLI will apply the current app as a module and generate an alias for the app to be run in isolation.  In the PLATFORM or APP context, the CLI will then add modules for all aliases defined, but only when an explicit module configuration is absent from `stripes.config.js`, or no `stripes.config.js` has been provided.
 
 3. Command configuration: Any relevant options passed in on the command line are applied to the configuration last.
 

--- a/lib/platform/stripes-platform.js
+++ b/lib/platform/stripes-platform.js
@@ -8,6 +8,7 @@ module.exports = class StripesPlatform {
     this.aliasService = new AliasService();
     this.isAppContext = context.type === 'app';
     this.aliases = {};
+    this.addAliasesAsModules = true;
 
     // Start with stripes.config.js or internal defaults
     this.applyDefaultConfig(stripesConfigFile);
@@ -24,10 +25,18 @@ module.exports = class StripesPlatform {
     this.applyCommandOptions(options);
   }
 
+  static loadStripesConfig(stripesConfigFile) {
+    return require(path.resolve(stripesConfigFile)); // eslint-disable-line
+  }
+
   applyDefaultConfig(stripesConfigFile) {
     // TODO: Validate incoming config
     if (stripesConfigFile) {
-      const stripesConfig = require(path.resolve(stripesConfigFile)); // eslint-disable-line
+      const stripesConfig = StripesPlatform.loadStripesConfig(stripesConfigFile);
+      // When modules are specified in a config file, do not automatically apply aliases as modules
+      if (stripesConfig.modules) {
+        this.addAliasesAsModules = false;
+      }
       this.config = mergeConfig(emptyConfig, stripesConfig);
     } else {
       this.config = mergeConfig(emptyConfig, defaultConfig);
@@ -63,7 +72,7 @@ module.exports = class StripesPlatform {
     const moduleNames = Object.getOwnPropertyNames(validAliases);
     for (const moduleName of moduleNames) {
       // Only include aliases with a type in the stripes.config modules
-      if (validAliases[moduleName].type) {
+      if (this.addAliasesAsModules && validAliases[moduleName].type) {
         this.config.modules[moduleName] = {};
       }
       this.aliases[moduleName] = validAliases[moduleName].path;

--- a/test/platform/stripes-platform.spec.js
+++ b/test/platform/stripes-platform.spec.js
@@ -81,6 +81,16 @@ describe('The stripes-platform', function () {
       expect(this.sut.config).to.have.property('modules').with.property('@folio/my-app');
     });
 
+    it('does not apply aliases to module config when a config file is provided', function () {
+      this.sandbox.stub(StripesPlatform, 'loadStripesConfig').returns({ okapi: {}, config: {}, modules: {} });
+      this.sut.applyDefaultConfig('stripes.config.js');
+      const validAliasMock = {
+        '@folio/my-app': { path: '/path/to/ui-my-app', type: 'app', isValid: true },
+      };
+      this.sut.applyAliasesToPlatform(validAliasMock);
+      expect(this.sut.config).to.have.property('modules').but.not.property('@folio/my-app');
+    });
+
     it('does not apply aliases of unspecified type to module config', function () {
       const validAliasMock = {
         '@folio/stripes-core': { path: '/path/to/stripes-core', isValid: true },


### PR DESCRIPTION
This change respects the `stripes.config.js` tenant module definition.  If the module configuration is omitted, or no `stripes.config.js` file is provided, then the CLI will revert to automatically adding previously defined aliases as modules.  

This allows for more explicit module definitions without having to alter aliases to add/remove modules for a tenant.  STCLI-18