### PR TITLE
Process aliases relative to .stripesclirc location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add option to serve an existing build. STCLI-26
 * When a config file with modules is provided, do not automatically apply aliases to module config. STCLI-18
+* Resolve alias paths relative to `.stripesclirc` config file location. Fixes STCLI-35
 
 
 ## [1.0.0](https://github.com/folio-org/stripes-cli/tree/v1.0.0) (2018-02-08)

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Any supported command-line positional or option can be defined.  For example:
 }
 ```
 
-Aliases for Stripes UI apps are also supported:
+Aliases for Stripes UI apps are also supported.  Aliases paths should be relative to the directory containing the `.stripesclirc` config file which defines the aliases.
 ```
 {
   "aliases": {

--- a/lib/platform/alias-service.js
+++ b/lib/platform/alias-service.js
@@ -16,7 +16,20 @@ module.exports = class AliasService {
     this.storageAliases = this.storage.getAllAliases();
 
     // Aliases stored with ".stripesclirc" file
-    this.configAliases = cliConfig.aliases || {};
+    this.configAliases = AliasService.normalizeConfigAliases(cliConfig.aliases, cliConfig.configPath);
+  }
+
+  static normalizeConfigAliases(configAliases, configPath) {
+    const aliases = Object.assign({}, configAliases);
+
+    if (configPath) {
+      const relativeBase = path.relative(cwd, path.parse(configPath).dir);
+      const moduleNames = Object.getOwnPropertyNames(aliases);
+      for (const moduleName of moduleNames) {
+        aliases[moduleName] = path.join(relativeBase, aliases[moduleName]);
+      }
+    }
+    return aliases;
   }
 
   addAlias(moduleName, relativePath) {
@@ -68,7 +81,7 @@ module.exports = class AliasService {
   // Validates a relative path alias and returns the absolute path
   validateAlias(moduleName, modulePath, parseOnly) {
     const absolutePath = path.isAbsolute(modulePath) ? modulePath : path.join(cwd, modulePath);
-    const packageJsonPath = path.join(absolutePath, '/package.json');
+    const packageJsonPath = path.join(absolutePath, 'package.json');
     let validationError = false;
     let stripesType;
     let hasNodeModules;

--- a/test/platform/alias-service.spec.js
+++ b/test/platform/alias-service.spec.js
@@ -29,8 +29,20 @@ describe('The alias-service', function () {
 
     it('loads aliases from config', function () {
       this.sandbox.stub(cliConfig, 'aliases').value(this.aliases);
+      // Simulate that the config file is in the current working directory
+      this.sandbox.stub(cliConfig, 'configPath').value(path.join(path.resolve(), '.stripesclirc'));
       this.sut = new AliasService(storageStub);
       expect(this.sut.configAliases).to.deep.equal(this.aliases);
+    });
+
+    it('loads alias relative to config file location', function () {
+      this.sandbox.stub(cliConfig, 'aliases').value(this.aliases);
+      // Simulate that the config file is up a directory
+      this.sandbox.stub(cliConfig, 'configPath').value(path.join(path.resolve(), '..', '.stripesclirc'));
+      this.sut = new AliasService(storageStub);
+      expect(this.sut.configAliases).to.deep.equal({
+        '@folio/users': '../../ui-users',
+      });
     });
   });
 


### PR DESCRIPTION
This will ensure alias definitions remain valid for all working directories.
Fixes STCLI-35