### PR TITLE
Check for an existing module config before assigning one

### DIFF
--- a/lib/platform/platform-config.js
+++ b/lib/platform/platform-config.js
@@ -1,3 +1,5 @@
+const { merge } = require('lodash');
+
 const defaultConfig = {
   okapi: {
     url: 'http://localhost:9130',
@@ -23,14 +25,8 @@ const emptyConfig = {
 };
 
 // Merge two stripes configurations
-// Replace with deep merge?
 function mergeConfig(base, extend) {
-  return {
-    okapi: Object.assign({}, base.okapi, extend.okapi),
-    config: Object.assign({}, base.config, extend.config),
-    modules: Object.assign({}, base.modules, extend.modules),
-    branding: Object.assign({}, base.branding, extend.branding),
-  };
+  return merge({}, base, extend);
 }
 
 module.exports = {

--- a/lib/platform/stripes-platform.js
+++ b/lib/platform/stripes-platform.js
@@ -48,11 +48,9 @@ module.exports = class StripesPlatform {
     if (!this.isAppContext || !moduleName) {
       return;
     }
-    if (!this.config.modules || !this.config.modules[moduleName]) {
-      const modules = {};
-      modules[moduleName] = {};
-      this.config = mergeConfig(this.config, { modules });
-    }
+    const modules = {};
+    modules[moduleName] = {};
+    this.config = mergeConfig(this.config, { modules });
     this.aliases[moduleName] = path.resolve();
   }
 

--- a/lib/platform/stripes-platform.js
+++ b/lib/platform/stripes-platform.js
@@ -48,9 +48,11 @@ module.exports = class StripesPlatform {
     if (!this.isAppContext || !moduleName) {
       return;
     }
-    const modules = {};
-    modules[moduleName] = {};
-    this.config = mergeConfig(this.config, { modules });
+    if (!this.config.modules || !this.config.modules[moduleName]) {
+      const modules = {};
+      modules[moduleName] = {};
+      this.config = mergeConfig(this.config, { modules });
+    }
     this.aliases[moduleName] = path.resolve();
   }
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "karma-mocha-reporter": "^2.2.5",
     "karma-webpack": "2.0.6",
     "kopy": "^8.2.3",
+    "lodash": "^4.17.5",
     "mocha": "^4.0.1",
     "node-fetch-npm": "^2.0.2",
     "resolve-from": "^4.0.0",

--- a/test/platform/stripes-platform.spec.js
+++ b/test/platform/stripes-platform.spec.js
@@ -38,6 +38,40 @@ describe('The stripes-platform', function () {
       expect(this.sut.config).to.have.property('modules').with.property('my-app');
     });
 
+    it('adds app module to an existing config', function () {
+      this.sut.isAppContext = true;
+      this.sut.config = {
+        modules: {
+          'not-my-app': { one: 'value' },
+        },
+      };
+      this.sut.applyVirtualAppPlatform('my-app');
+      expect(this.sut.config).to.have.property('modules').with.property('my-app');
+    });
+
+    it('does not override current app module\'s existing config', function () {
+      this.sut.isAppContext = true;
+      this.sut.config = {
+        modules: {
+          'my-app': { two: 'value' },
+        },
+      };
+      this.sut.applyVirtualAppPlatform('my-app');
+      expect(this.sut.config).to.have.property('modules').with.property('my-app').with.property('two');
+    });
+
+    it('does not override other app module configs', function () {
+      this.sut.isAppContext = true;
+      this.sut.config = {
+        modules: {
+          'not-my-app': { one: 'value' },
+          'my-app': { two: 'value' },
+        },
+      };
+      this.sut.applyVirtualAppPlatform('my-app');
+      expect(this.sut.config).to.have.property('modules').with.property('not-my-app').with.property('one');
+    });
+
     it('adds app alias', function () {
       this.sut.isAppContext = true;
       this.sut.applyVirtualAppPlatform('my-app');


### PR DESCRIPTION
This will prevent a user-supplied module config from getting overriden by the CLI's generated module config in the CLI's single app context.  Fixes STCLI-44