### PR TITLE
STCLI-34 update instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * New `workspace` command, STCLI-41
 * Fix issue assigning isGlobalYarn to context, STCLI-45
 * Simplify `app create` options, STLCI-46
+* Static upgrade message to omit false npm reference, STCLI-34
 
 
 ## [1.0.0](https://github.com/folio-org/stripes-cli/tree/v1.0.0) (2018-02-08)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ Upgrade your globally installed CLI with the following command:
 yarn global upgrade @folio/stripes-cli
 ```
 
+If your CLI is installed locally, use:
+```
+yarn upgrade @folio/stripes-cli
+```
+
 ## Issues
 
 See project [STCLI](https://issues.folio.org/browse/STCLI) in the [FOLIO issue tracker](https://dev.folio.org/guidelines/issue-tracker).

--- a/lib/stripes-cli.js
+++ b/lib/stripes-cli.js
@@ -12,9 +12,11 @@ process.title = 'stripes-cli';
 // Update notifier runs async in a child process
 updateNotifier({
   pkg: packageJson,
-  updateCheckInterval: 1000 * 60 * 60 * 24 * 1, // TODO: Reduce frequency after v1
+  updateCheckInterval: 1000 * 60 * 60 * 24 * 7,
 }).notify({
   isGlobal: isInstalledGlobally,
+  // TODO: Consider reverting to default message once update-notifier detects global yarn installs
+  message: 'Update available - Refer to README.md:\nhttps://github.com/folio-org/stripes-cli',
 });
 
 // Monkey-patch Yargs to inform user of an unrecognized command when no suggestions could be provided


### PR DESCRIPTION
Define a static upgrade message pointing user to the README to avoid misleading upgrade instructions when using Yarn.