### PR TITLE
STCLI-52, STCLI-54, STCLI-55 Okapi experiments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 1.2.0 (IN PROGRESS)
 * Exit process when Nightmare tests pass, fixes STCLI-49
+* Fix --install typo, STCLI-50
+* Updated ui-module inventory
+* New `mod` commands to generate descriptors and view tenant modules, STCLI-52
+* New `app perms` command to view permissions for an app, STCLI-54
+* Support for stdin, added initially to mod enable/disable and perm assign, STCLI-55
+
 
 ## 1.1.0 (https://github.com/folio-org/stripes-cli/tree/v1.1.0) (2018-4-13)
 
@@ -23,8 +29,6 @@
 * Simplify `app create` options, STLCI-46
 * Static upgrade message to omit false npm reference, STCLI-34
 * Add debug notes and VSCode configuration, STCLI-47
-* Fix --install typo, STCLI-50
-* ui-items has been deprecated
 
 
 ## [1.0.0](https://github.com/folio-org/stripes-cli/tree/v1.0.0) (2018-02-08)

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -5,6 +5,7 @@ This following command documentation is largely generated from the CLI's own bui
 * [Common options](#common-options)
 * [`app` command](#app-command)
     * [`app create` command](#app-create-command)
+    * [`app perms` command](#app-perms-command)
 * [`serve` command](#serve-command)
 * [`build` command](#build-command)
 * [`test` command (work in progress)](#test-command-work-in-progress)
@@ -27,6 +28,9 @@ This following command documentation is largely generated from the CLI's own bui
     * [`mod enable` command](#mod-enable-command)
     * [`mod disable` command](#mod-disable-command)
     * [`mod update` command](#mod-update-command)
+    * [`mod descriptor` command](#mod-descriptor-command)
+    * [`mod view` command](#mod-view-command)
+    * [`mod install` command (work in progress)](#mod-install-command-work-in-progress)
 * [`perm` command](#perm-command)
     * [`perm create` command](#perm-create-command)
     * [`perm assign` command](#perm-assign-command)
@@ -66,6 +70,7 @@ stripes app <command>
 
 Sub-commands:
 * `stripes app create [name]`
+* `stripes app perms`
 
 
 ### `app create` command
@@ -90,7 +95,6 @@ Option | Description | Type | Notes
 `--assign` | Assign new app permission to the given user (includes pushing module descriptor to Okapi and enabling for tenant) | string | 
 
 
-
 Examples:
 
 Create new Stripes UI app, directory, and install dependencies:
@@ -104,6 +108,26 @@ stripes app create "Hello World" --assign diku_admin
 Create new Stripes UI app, but do not install dependencies:
 ```
 stripes app create "Hello World" --no-install
+```
+
+### `app perms` command
+
+View list of permissions for the current app (app context)
+
+Usage:
+```
+stripes app perms
+```
+
+Examples:
+
+View current app permissions:
+```
+stripes app perms
+```
+Assign current app permissions to user diku_admin:
+```
+stripes app perms | stripes perm assign --user diku_admin
 ```
 
 
@@ -541,10 +565,13 @@ stripes mod <command>
 
 Sub-commands:
 * `stripes mod add`
+* `stripes mod descriptor`
 * `stripes mod disable`
 * `stripes mod enable`
+* `stripes mod install`
 * `stripes mod remove`
 * `stripes mod update`
+* `stripes mod view`
 
 ### `mod add` command
 
@@ -601,18 +628,28 @@ Option | Description | Type | Notes
 ---|---|---|---
 `--okapi` | Specify an Okapi URL | string | 
 `--tenant` | Specify a tenant ID | string | 
+`--ids` | Module descriptor ids | array | supports stdin
 
 
 Examples:
 
+Enable the current ui-module (app context):
 ```
-stripes mod enable
+stripes mod enable --tenant diku
+```
+Enable module ids "one" and "two" for tenant diku:
+```
+stripes mod enable --ids one two --tenant diku
+```
+Enable module ids "one" and "two" for tenant diku with stdin:
+```
+echo one two | stripes mod enable --tenant diku
 ```
 
 
 ### `mod disable` command
 
-Disable an app module descriptor for a tenant in Okapi
+Disable modules for a tenant in Okapi
 
 Usage:
 ```
@@ -623,11 +660,22 @@ Option | Description | Type | Notes
 ---|---|---|---
 `--okapi` | Specify an Okapi URL | string | 
 `--tenant` | Specify a tenant ID | string | 
+`--ids` | Module descriptor ids | array | supports stdin
+
 
 Examples:
 
+Disable the current ui-module (app context):
 ```
-stripes mod disable
+stripes mod disable --tenant diku
+```
+Disable module ids "one" and "two" for tenant diku:
+```
+stripes mod disable --ids one two --tenant diku
+```
+Disable module ids "one" and "two" for tenant diku with stdin:
+```
+echo one two | stripes mod disable --tenant diku
 ```
 
 
@@ -650,6 +698,85 @@ Option | Description | Type | Notes
 stripes mod update
 ```
 
+### `mod descriptor` command
+
+Generate module descriptors for an app or platform.
+
+Usage:
+```
+stripes mod descriptor
+```
+
+
+Option | Description | Type | Notes
+---|---|---|---
+`--configFile` | File containing a Stripes tenant configuration (platform context only) | string | 
+`--full` | Return full module descriptor JSON | boolean | default: false 
+
+
+Examples:
+
+Display module descriptor id for current app:
+```
+stripes mod descriptor
+```
+Display module descriptor ids for platform:
+```
+stripes mod descriptor --configFile stripes.config.js
+```
+Display full module descriptor as JSON:
+```
+stripes mod descriptor --full
+```
+
+### `mod view` command
+
+View enabled module ids for a tenant in Okapi
+
+Usage:
+```
+stripes mod view
+```
+
+Option | Description | Type | Notes
+---|---|---|---
+`--okapi` | Specify an Okapi URL | string | 
+`--tenant` | Specify a tenant ID | string | 
+
+
+Examples:
+
+View enabled module ids for tenant diku:
+```
+stripes mod view --tenant diku
+```
+
+### `mod install` command (work in progress)
+
+Enable, disable, or upgrade one or more modules for a tenant in Okapi (work in progress)
+
+Usage:
+```
+stripes mod install
+```
+
+Option | Description | Type | Notes
+---|---|---|---
+`--okapi` | Specify an Okapi URL | string | 
+`--tenant` | Specify a tenant ID | string | 
+`--ids` | Module descriptor ids | array | supports stdin
+
+
+Examples:
+
+Install modules "one" and "two":
+```
+stripes mod install --ids one two --tenant diku
+```
+Install module ids "one" and "two" using stdin:
+```
+echo one two | stripes mod install --tenant diku
+```
 
 ## `perm` command
 
@@ -713,14 +840,21 @@ stripes perm assign
 
 Option | Description | Type | Notes
 ---|---|---|---
-`--name` | Name of the permission | string | 
-`--user` | Username to assign permission to | string | alias: assign  
+`--name` | Name of the permission | string | supports stdin
+`--user` | Username to assign permission to | string | alias: assign
 `--okapi` | Specify an Okapi URL | string | 
 `--tenant` | Specify a tenant ID | string | 
 
+
 Examples:
+
+Assign permission to user diku_admin:
 ```
-stripes perm assign
+stripes perm assign --name module.hello-world.enabled --user diku_admin
+```
+Assign permissions from user jack to user jill:
+```
+stripes perm view --user jack | stripes perm assign --user jill
 ```
 
 ### `perm view` command

--- a/doc/dev-guide.md
+++ b/doc/dev-guide.md
@@ -7,6 +7,7 @@
 * [Commands](#commands)
     * [Options](#options)
     * [Interactive input](#interactive-input)
+    * [Standard input](#standard-input)
     * [Grouping](#grouping)
 * [Logging](#logging)
 * [Okapi Client](#okapi-client)
@@ -163,6 +164,19 @@ password: {
   },
 },
 ```
+
+### Standard input
+
+When accepting standard input (stdin), use one of the available handlers in `stdin-handler`.  Available stdin handlers include `stdinStringHandler`, `stdinArrayHandler`, and `stdinJsonHandler` for parsing strings, arrays, and JSON.
+
+The following example will parse `stdin`, when present, as an array of whitespace-delimited values assign the array to the command's `ids` option:
+
+```javascript
+handler: mainHandler(
+  stdinArrayHandler('ids', enableModuleCommand)
+),
+```
+
 
 ### Grouping
 
@@ -338,7 +352,7 @@ It is also possible set the wildcard for all namespaces:
 ```
 DEBUG=* stripes serve
 ```
-**Note:** The above will enable logging for all packages that happen to be instrumented with `debug`, including `express`.
+**Note:** The above will enable logging for all packages that happen to be instrumented with `debug`, including `express` and `babel`.
 
 Some of the available diagnostic output can be lengthy.  The `debug` utility writes to stderr, so if you would like to send this content in a file, you can do so with:
 ```

--- a/doc/dev-guide.md
+++ b/doc/dev-guide.md
@@ -167,9 +167,11 @@ password: {
 
 ### Standard input
 
-When accepting standard input (stdin), use one of the available handlers in `stdin-handler`.  Available stdin handlers include `stdinStringHandler`, `stdinArrayHandler`, and `stdinJsonHandler` for parsing strings, arrays, and JSON.
+To accept standard input (stdin) within a command, wrap the command's handler with one of the CLI's stdin handlers from `lib/cli/stdin-handler.js`.  Available stdin handlers include `stdinStringHandler`, `stdinArrayHandler`, and `stdinJsonHandler` for parsing string, array, and JSON input.  The `stdinArrayHandler` splits on whitespace, including line breaks, to make accepting multi-line input easy. 
 
-The following example will parse `stdin`, when present, as an array of whitespace-delimited values assign the array to the command's `ids` option:
+When the invoked, each stdin handler will parse standard input and assign the result to the specified option key.  From within the command, simply access the value as you would any other option.
+
+For example, the following will assign `stdin`, parsed as an array, to the `ids` option:
 
 ```javascript
 handler: mainHandler(

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -497,7 +497,7 @@ If the `--push` and `--assign` options are omitted (or the permissions were crea
 
 ```
 stripes mod update
-stripes app perms | stripes perms --user diku_admin
+stripes app perms | stripes perm assign --user diku_admin
 ```
 
 

--- a/lib/cli/context.js
+++ b/lib/cli/context.js
@@ -1,7 +1,6 @@
 const logger = require('./logger')();
 const path = require('path');
 const isInstalledGlobally = require('is-installed-globally');
-const generateModuleDescriptor = require('./generate-module-descriptor');
 // TODO: Yarn 1.5.1 changed global install directory on Windows, 'global-dirs' does not yet reflect this
 // https://github.com/yarnpkg/yarn/pull/5336
 const globalDirs = require('global-dirs');
@@ -51,7 +50,6 @@ function getContext(dir) {
   if (cwdPackageJson.stripes) {
     ctx.type = cwdPackageJson.stripes.type;
     ctx.moduleName = cwdPackageJson.name;
-    ctx.moduleDescriptor = generateModuleDescriptor(cwdPackageJson);
     return ctx;
   }
 

--- a/lib/cli/stdin-handler.js
+++ b/lib/cli/stdin-handler.js
@@ -1,0 +1,43 @@
+const logger = require('./logger')();
+const getStdin = require('get-stdin');
+
+function stdinStringHandler(name, nextHandler) {
+  return (argv, ctx) => {
+    return getStdin().then(stdin => {
+      if (stdin) {
+        argv[name] = stdin;
+      }
+      return nextHandler(argv, ctx);
+    });
+  };
+}
+
+// Parse stdin as JSON
+function stdinJsonHandler(name, nextHandler) {
+  return (argv, ctx) => {
+    return getStdin().then(stdin => {
+      if (stdin) {
+        argv[name] = JSON.parse(stdin);
+      }
+      return nextHandler(argv, ctx);
+    });
+  };
+}
+
+// Parse stdin as an array split on whitespace
+function stdinArrayHandler(name, nextHandler) {
+  return (argv, ctx) => {
+    return getStdin().then(stdin => {
+      if (stdin) {
+        argv[name] = stdin.trim().split(/\s+/);
+      }
+      return nextHandler(argv, ctx);
+    });
+  };
+}
+
+module.exports = {
+  stdinStringHandler,
+  stdinJsonHandler,
+  stdinArrayHandler,
+};

--- a/lib/commands/app/perms.js
+++ b/lib/commands/app/perms.js
@@ -1,0 +1,27 @@
+const importLazy = require('import-lazy')(require);
+
+const path = importLazy('path');
+const { mainHandler } = importLazy('../../cli/main-handler');
+
+function appPermsCommand(argv, context) {
+  if (context.type !== 'app') {
+    console.log('"app perms" only works in the APP context');
+    return;
+  }
+
+  const packageJson = require(path.join(context.cwd, 'package.json')); // eslint-disable-line
+  const permissionSets = packageJson.stripes ? packageJson.stripes.permissionSets : [];
+
+  permissionSets.forEach(permission => console.log(permission.permissionName));
+}
+
+module.exports = {
+  command: 'perms',
+  describe: 'View list of permissions for the current app (app context)',
+  builder: (yargs) => {
+    yargs
+      .example('$0 app perms', '');
+    return yargs;
+  },
+  handler: mainHandler(appPermsCommand),
+};

--- a/lib/commands/app/perms.js
+++ b/lib/commands/app/perms.js
@@ -20,7 +20,8 @@ module.exports = {
   describe: 'View list of permissions for the current app (app context)',
   builder: (yargs) => {
     yargs
-      .example('$0 app perms', '');
+      .example('$0 app perms', 'View current app permissions')
+      .example('$0 app perms | $0 perm assign --user diku_admin', 'Assign current app permissions to user diku_admin');
     return yargs;
   },
   handler: mainHandler(appPermsCommand),

--- a/lib/commands/mod/add.js
+++ b/lib/commands/mod/add.js
@@ -14,9 +14,10 @@ function addModuleDescriptorCommand(argv, context) {
   }
 
   const okapi = new Okapi(argv.okapi, argv.tenant);
-  const moduleService = new ModuleService(okapi, context);
+  const moduleService = new ModuleService(okapi);
 
-  return moduleService.addModuleDescriptor(context.moduleDescriptor)
+  const descriptors = ModuleService.getModuleDescriptorsFromContext(context);
+  return moduleService.addModuleDescriptor(descriptors[0])
     .then((response) => {
       if (response.alreadyExists) {
         console.log(`Module descriptor ${response.id} already exists in Okapi`);

--- a/lib/commands/mod/descriptor.js
+++ b/lib/commands/mod/descriptor.js
@@ -1,0 +1,37 @@
+const importLazy = require('import-lazy')(require);
+
+const { mainHandler } = importLazy('../../cli/main-handler');
+const ModuleService = importLazy('../../okapi/module-service');
+
+function moduleDescriptorCommand(argv, context) {
+  const descriptors = ModuleService.getModuleDescriptorsFromContext(context, argv.configFile);
+
+  if (argv.ids) {
+    descriptors.forEach(descriptor => console.log(descriptor.id));
+  } else {
+    console.log(JSON.stringify(descriptors, null, 2));
+  }
+
+  return Promise.resolve(descriptors);
+}
+
+module.exports = {
+  command: 'descriptor',
+  describe: 'Generate module descriptors for an app or platform',
+  builder: (yargs) => {
+    yargs
+      .positional('configFile', {
+        describe: 'File containing a Stripes tenant configuration',
+        type: 'string',
+      })
+      .option('ids', {
+        describe: 'Only return module ids',
+        type: 'boolean',
+        default: false,
+      })
+      .example('$0 mod descriptor', '')
+      .example('$0 mod descriptor --ids', '');
+    return yargs;
+  },
+  handler: mainHandler(moduleDescriptorCommand),
+};

--- a/lib/commands/mod/descriptor.js
+++ b/lib/commands/mod/descriptor.js
@@ -11,17 +11,15 @@ function moduleDescriptorCommand(argv, context) {
   } else {
     descriptors.forEach(descriptor => console.log(descriptor.id));
   }
-
-  return Promise.resolve(descriptors);
 }
 
 module.exports = {
   command: 'descriptor',
-  describe: 'Generate module descriptors for an app or platform',
+  describe: 'Generate module descriptors for an app or platform.',
   builder: (yargs) => {
     yargs
-      .positional('configFile', {
-        describe: 'File containing a Stripes tenant configuration',
+      .option('configFile', {
+        describe: 'File containing a Stripes tenant configuration (platform context only)',
         type: 'string',
       })
       .option('full', {
@@ -29,8 +27,9 @@ module.exports = {
         type: 'boolean',
         default: false,
       })
-      .example('$0 mod descriptor', '')
-      .example('$0 mod descriptor --full', '');
+      .example('$0 mod descriptor', 'Display module descriptor id for current app')
+      .example('$0 mod descriptor --configFile stripes.config.js', 'Display module descriptor ids for platform')
+      .example('$0 mod descriptor --full', 'Display full module descriptor as JSON');
     return yargs;
   },
   handler: mainHandler(moduleDescriptorCommand),

--- a/lib/commands/mod/descriptor.js
+++ b/lib/commands/mod/descriptor.js
@@ -6,10 +6,10 @@ const ModuleService = importLazy('../../okapi/module-service');
 function moduleDescriptorCommand(argv, context) {
   const descriptors = ModuleService.getModuleDescriptorsFromContext(context, argv.configFile);
 
-  if (argv.ids) {
-    descriptors.forEach(descriptor => console.log(descriptor.id));
-  } else {
+  if (argv.full) {
     console.log(JSON.stringify(descriptors, null, 2));
+  } else {
+    descriptors.forEach(descriptor => console.log(descriptor.id));
   }
 
   return Promise.resolve(descriptors);
@@ -24,13 +24,13 @@ module.exports = {
         describe: 'File containing a Stripes tenant configuration',
         type: 'string',
       })
-      .option('ids', {
-        describe: 'Only return module ids',
+      .option('full', {
+        describe: 'Return full module descriptor JSON',
         type: 'boolean',
         default: false,
       })
       .example('$0 mod descriptor', '')
-      .example('$0 mod descriptor --ids', '');
+      .example('$0 mod descriptor --full', '');
     return yargs;
   },
   handler: mainHandler(moduleDescriptorCommand),

--- a/lib/commands/mod/disable.js
+++ b/lib/commands/mod/disable.js
@@ -30,7 +30,7 @@ module.exports = {
   builder: (yargs) => {
     yargs
       .option('ids', {
-        describe: 'Module descriptor ids to disable (or use stdin)',
+        describe: 'Module descriptor ids',
         type: 'array',
       })
       .example('$0 mod disable --tenant diku', 'Disable the current ui-module (app context)')

--- a/lib/commands/mod/disable.js
+++ b/lib/commands/mod/disable.js
@@ -14,9 +14,10 @@ function disableModuleCommand(argv, context) {
   }
 
   const okapi = new Okapi(argv.okapi, argv.tenant);
-  const moduleService = new ModuleService(okapi, context);
+  const moduleService = new ModuleService(okapi);
 
-  return moduleService.disableModuleForTenant(context.moduleDescriptor, argv.tenant)
+  const descriptors = ModuleService.getModuleDescriptorsFromContext(context);
+  return moduleService.disableModuleForTenant(descriptors[0], argv.tenant)
     .then((response) => {
       if (response.something) {
         console.log(`Module ${response.id} not associated with tenant ${argv.tenant}`);

--- a/lib/commands/mod/disable.js
+++ b/lib/commands/mod/disable.js
@@ -34,8 +34,8 @@ module.exports = {
         type: 'array',
       })
       .example('$0 mod disable --tenant diku', 'Disable the current ui-module (app context)')
-      .example('$0 mod disable --ids folio_one-1.0.0 folio_two-1.0.0 --tenant diku', 'Disable specific module ids')
-      .example('echo folio_one-1.0.0 folio_two-1.0.0 | $0 mod disable --tenant diku', 'Disable specific module ids with stdin');
+      .example('$0 mod disable --ids one two --tenant diku', 'Disable module ids "one" and "two" for tenant diku')
+      .example('echo one two | $0 mod disable --tenant diku', 'Disable module ids "one" and "two" for tenant diku with stdin');
     return applyOptions(yargs, Object.assign({}, okapiOptions));
   },
   handler: mainHandler(stdinArrayHandler('ids', disableModuleCommand)),

--- a/lib/commands/mod/disable.js
+++ b/lib/commands/mod/disable.js
@@ -4,36 +4,39 @@ const { mainHandler } = importLazy('../../cli/main-handler');
 const Okapi = importLazy('../../okapi');
 const ModuleService = importLazy('../../okapi/module-service');
 const { applyOptions, okapiOptions } = importLazy('../common-options');
-
+const { stdinArrayHandler } = importLazy('../../cli/stdin-handler');
 
 function disableModuleCommand(argv, context) {
-  // check for app context, then load package.json
-  if (context.type !== 'app') {
-    console.log('"mod disable" only works in the APP context');
+  const okapi = new Okapi(argv.okapi, argv.tenant);
+  const moduleService = new ModuleService(okapi);
+  let descriptorIds;
+
+  if (argv.ids) {
+    descriptorIds = argv.ids;
+  } else if (context.type === 'app') {
+    descriptorIds = ModuleService.getModuleDescriptorsFromContext(context).map(descriptor => descriptor.id);
+  } else {
+    console.log('No module descriptor ids provided');
     return Promise.reject();
   }
 
-  const okapi = new Okapi(argv.okapi, argv.tenant);
-  const moduleService = new ModuleService(okapi);
-
-  const descriptors = ModuleService.getModuleDescriptorsFromContext(context);
-  return moduleService.disableModuleForTenant(descriptors[0], argv.tenant)
-    .then((response) => {
-      if (response.something) {
-        console.log(`Module ${response.id} not associated with tenant ${argv.tenant}`);
-      } else {
-        console.log(`Module ${response.id} no longer associated with tenant ${argv.tenant}`);
-      }
-    });
+  return moduleService.disableModulesForTenant(descriptorIds, argv.tenant)
+    .then((responses) => responses.forEach(response => console.log(`Module ${response.id} no longer associated with tenant ${argv.tenant}`)));
 }
 
 module.exports = {
   command: 'disable',
-  describe: 'Disable an app module descriptor for a tenant in Okapi',
+  describe: 'Disable modules for a tenant in Okapi',
   builder: (yargs) => {
     yargs
-      .example('$0 mod disable --tenant diku', '');
+      .option('ids', {
+        describe: 'Module descriptor ids to disable (or use stdin)',
+        type: 'array',
+      })
+      .example('$0 mod disable --tenant diku', 'Disable the current ui-module (app context)')
+      .example('$0 mod disable --ids folio_one-1.0.0 folio_two-1.0.0 --tenant diku', 'Disable specific module ids')
+      .example('echo folio_one-1.0.0 folio_two-1.0.0 | $0 mod disable --tenant diku', 'Disable specific module ids with stdin');
     return applyOptions(yargs, Object.assign({}, okapiOptions));
   },
-  handler: mainHandler(disableModuleCommand),
+  handler: mainHandler(stdinArrayHandler('ids', disableModuleCommand)),
 };

--- a/lib/commands/mod/enable.js
+++ b/lib/commands/mod/enable.js
@@ -4,26 +4,32 @@ const { mainHandler } = importLazy('../../cli/main-handler');
 const Okapi = importLazy('../../okapi');
 const ModuleService = importLazy('../../okapi/module-service');
 const { applyOptions, okapiOptions } = importLazy('../common-options');
-
+const { stdinArrayHandler } = importLazy('../../cli/stdin-handler');
 
 function enableModuleCommand(argv, context) {
-  // check for app context, then load package.json
-  if (context.type !== 'app') {
-    console.log('"mod enable" only works in the APP context');
-    return Promise.reject();
-  }
 
   const okapi = new Okapi(argv.okapi, argv.tenant);
   const moduleService = new ModuleService(okapi);
+  let descriptorIds;
 
-  const descriptors = ModuleService.getModuleDescriptorsFromContext(context);
-  return moduleService.enableModuleForTenant(descriptors[0], argv.tenant)
-    .then((response) => {
-      if (response.alreadyExists) {
-        console.log(`Module ${response.id} already associated with tenant ${argv.tenant}`);
-      } else {
-        console.log(`Module ${response.id} associated with tenant ${argv.tenant}`);
-      }
+  if (argv.ids) {
+    descriptorIds = argv.ids;
+  } else if (context.type === 'app') {
+    descriptorIds = ModuleService.getModuleDescriptorsFromContext(context).map(descriptor => descriptor.id);
+  } else {
+    console.log('No module descriptor ids provided');
+    return Promise.reject();
+  }
+
+  return moduleService.enableModulesForTenant(descriptorIds, argv.tenant)
+    .then((responses) => {
+      responses.forEach(response => {
+        if (response.alreadyExists) {
+          console.log(`Module ${response.id} already associated with tenant ${argv.tenant}`);
+        } else {
+          console.log(`Module ${response.id} associated with tenant ${argv.tenant}`);
+        }
+      });
     });
 }
 
@@ -35,5 +41,5 @@ module.exports = {
       .example('$0 mod enable --tenant diku', '');
     return applyOptions(yargs, Object.assign({}, okapiOptions));
   },
-  handler: mainHandler(enableModuleCommand),
+  handler: mainHandler(stdinArrayHandler('ids', enableModuleCommand)),
 };

--- a/lib/commands/mod/enable.js
+++ b/lib/commands/mod/enable.js
@@ -7,7 +7,6 @@ const { applyOptions, okapiOptions } = importLazy('../common-options');
 const { stdinArrayHandler } = importLazy('../../cli/stdin-handler');
 
 function enableModuleCommand(argv, context) {
-
   const okapi = new Okapi(argv.okapi, argv.tenant);
   const moduleService = new ModuleService(okapi);
   let descriptorIds;
@@ -38,7 +37,13 @@ module.exports = {
   describe: 'Enable an app module descriptor for a tenant in Okapi',
   builder: (yargs) => {
     yargs
-      .example('$0 mod enable --tenant diku', '');
+      .option('ids', {
+        describe: 'Module descriptor ids',
+        type: 'array',
+      })
+      .example('$0 mod enable --tenant diku', 'Enable the current ui-module (app context)')
+      .example('$0 mod enable --ids folio_one-1.0.0 folio_two-1.0.0 --tenant diku', 'Enable specific module ids')
+      .example('echo folio_one-1.0.0 folio_two-1.0.0 | $0 mod enable --tenant diku', 'Enable specific module ids with stdin');
     return applyOptions(yargs, Object.assign({}, okapiOptions));
   },
   handler: mainHandler(stdinArrayHandler('ids', enableModuleCommand)),

--- a/lib/commands/mod/enable.js
+++ b/lib/commands/mod/enable.js
@@ -14,9 +14,10 @@ function enableModuleCommand(argv, context) {
   }
 
   const okapi = new Okapi(argv.okapi, argv.tenant);
-  const moduleService = new ModuleService(okapi, context);
+  const moduleService = new ModuleService(okapi);
 
-  return moduleService.enableModuleForTenant(context.moduleDescriptor, argv.tenant)
+  const descriptors = ModuleService.getModuleDescriptorsFromContext(context);
+  return moduleService.enableModuleForTenant(descriptors[0], argv.tenant)
     .then((response) => {
       if (response.alreadyExists) {
         console.log(`Module ${response.id} already associated with tenant ${argv.tenant}`);

--- a/lib/commands/mod/enable.js
+++ b/lib/commands/mod/enable.js
@@ -42,8 +42,8 @@ module.exports = {
         type: 'array',
       })
       .example('$0 mod enable --tenant diku', 'Enable the current ui-module (app context)')
-      .example('$0 mod enable --ids folio_one-1.0.0 folio_two-1.0.0 --tenant diku', 'Enable specific module ids')
-      .example('echo folio_one-1.0.0 folio_two-1.0.0 | $0 mod enable --tenant diku', 'Enable specific module ids with stdin');
+      .example('$0 mod enable --ids one two --tenant diku', 'Enable module ids "one" and "two" for tenant diku')
+      .example('echo one two | $0 mod enable --tenant diku', 'Enable module ids "one" and "two" for tenant diku with stdin');
     return applyOptions(yargs, Object.assign({}, okapiOptions));
   },
   handler: mainHandler(stdinArrayHandler('ids', enableModuleCommand)),

--- a/lib/commands/mod/install.js
+++ b/lib/commands/mod/install.js
@@ -1,0 +1,37 @@
+const importLazy = require('import-lazy')(require);
+
+const { mainHandler } = importLazy('../../cli/main-handler');
+const Okapi = importLazy('../../okapi');
+const ModuleService = importLazy('../../okapi/module-service');
+const { applyOptions, okapiOptions } = importLazy('../common-options');
+
+
+function installModulesCommand(argv, context) {
+  if (!argv.modules) {
+    console.log('No modules specified.');
+    return Promise.resolve();
+  }
+
+  const okapi = new Okapi(argv.okapi, argv.tenant);
+  const moduleService = new ModuleService(okapi, context);
+
+  return moduleService.installModulesForTenant(argv.modules, argv.tenant)
+    .then((response) => {
+      console.log(response);
+    });
+}
+
+module.exports = {
+  command: 'install',
+  describe: 'Enable, disable, or upgrade one or more modules for a tenant in Okapi',
+  builder: (yargs) => {
+    yargs
+      .option('modules', {
+        describe: 'List of modules to enable',
+        type: 'array'
+      })
+      .example('$0 mod install --modules folio_users-2.12.2000308 folio_search-1.1.100082 --tenant diku', '');
+    return applyOptions(yargs, Object.assign({}, okapiOptions));
+  },
+  handler: mainHandler(installModulesCommand),
+};

--- a/lib/commands/mod/install.js
+++ b/lib/commands/mod/install.js
@@ -4,18 +4,19 @@ const { mainHandler } = importLazy('../../cli/main-handler');
 const Okapi = importLazy('../../okapi');
 const ModuleService = importLazy('../../okapi/module-service');
 const { applyOptions, okapiOptions } = importLazy('../common-options');
+const { stdinArrayHandler } = importLazy('../../cli/stdin-handler');
 
 
 function installModulesCommand(argv, context) {
-  if (!argv.modules) {
-    console.log('No modules specified.');
+  if (!argv.ids) {
+    console.log('No module descriptor ids specified.');
     return Promise.resolve();
   }
 
   const okapi = new Okapi(argv.okapi, argv.tenant);
   const moduleService = new ModuleService(okapi, context);
 
-  return moduleService.installModulesForTenant(argv.modules, argv.tenant)
+  return moduleService.installModulesForTenant(argv.ids, argv.tenant)
     .then((response) => {
       console.log(response);
     });
@@ -26,12 +27,13 @@ module.exports = {
   describe: 'Enable, disable, or upgrade one or more modules for a tenant in Okapi',
   builder: (yargs) => {
     yargs
-      .option('modules', {
-        describe: 'List of modules to enable',
+      .option('ids', {
+        describe: 'Module descriptor ids',
         type: 'array'
       })
-      .example('$0 mod install --modules folio_users-2.12.2000308 folio_search-1.1.100082 --tenant diku', '');
+      .example('$0 mod install --ids folio_one-1.0.0 folio_two-1.0.0 --tenant diku', '')
+      .example('echo folio_one-1.0.0 folio_two-1.0.0 | $0 mod install --tenant diku', '');
     return applyOptions(yargs, Object.assign({}, okapiOptions));
   },
-  handler: mainHandler(installModulesCommand),
+  handler: mainHandler(stdinArrayHandler('ids', installModulesCommand)),
 };

--- a/lib/commands/mod/install.js
+++ b/lib/commands/mod/install.js
@@ -24,15 +24,15 @@ function installModulesCommand(argv, context) {
 
 module.exports = {
   command: 'install',
-  describe: 'Enable, disable, or upgrade one or more modules for a tenant in Okapi',
+  describe: 'Enable, disable, or upgrade one or more modules for a tenant in Okapi (work in progress)',
   builder: (yargs) => {
     yargs
       .option('ids', {
         describe: 'Module descriptor ids',
         type: 'array'
       })
-      .example('$0 mod install --ids folio_one-1.0.0 folio_two-1.0.0 --tenant diku', '')
-      .example('echo folio_one-1.0.0 folio_two-1.0.0 | $0 mod install --tenant diku', '');
+      .example('$0 mod install --ids one two --tenant diku', 'Install module ids "one" and "two"')
+      .example('echo one two | $0 mod install --tenant diku', 'Install module ids "one" and "two" using stdin');
     return applyOptions(yargs, Object.assign({}, okapiOptions));
   },
   handler: mainHandler(stdinArrayHandler('ids', installModulesCommand)),

--- a/lib/commands/mod/remove.js
+++ b/lib/commands/mod/remove.js
@@ -14,9 +14,10 @@ function removeModuleDescriptorCommand(argv, context) {
   }
 
   const okapi = new Okapi(argv.okapi, argv.tenant);
-  const moduleService = new ModuleService(okapi, context);
+  const moduleService = new ModuleService(okapi);
 
-  return moduleService.removeModuleDescriptor(context.moduleDescriptor)
+  const descriptors = ModuleService.getModuleDescriptorsFromContext(context);
+  return moduleService.removeModuleDescriptor(descriptors[0])
     .then((response) => {
       if (response.doesNotExist) {
         console.log(`Module descriptor ${response.id} does not exist in Okapi`);

--- a/lib/commands/mod/update.js
+++ b/lib/commands/mod/update.js
@@ -14,9 +14,10 @@ function updateModuleDescriptorCommand(argv, context) {
   }
 
   const okapi = new Okapi(argv.okapi, argv.tenant);
-  const moduleService = new ModuleService(okapi, context);
+  const moduleService = new ModuleService(okapi);
 
-  return moduleService.updateModuleDescriptor(context.moduleDescriptor)
+  const descriptors = ModuleService.getModuleDescriptorsFromContext(context);
+  return moduleService.updateModuleDescriptor(descriptors[0])
     .then((response) => {
       if (response.success) {
         console.log(`Module descriptor ${response.id} updated in Okapi`);

--- a/lib/commands/mod/view.js
+++ b/lib/commands/mod/view.js
@@ -1,0 +1,35 @@
+const importLazy = require('import-lazy')(require);
+
+const { mainHandler } = importLazy('../../cli/main-handler');
+const Okapi = importLazy('../../okapi');
+const ModuleService = importLazy('../../okapi/module-service');
+const { applyOptions, okapiOptions } = importLazy('../common-options');
+
+
+function viewModuleCommand(argv, context) {
+  const okapi = new Okapi(argv.okapi, argv.tenant);
+  const moduleService = new ModuleService(okapi, context);
+
+  return moduleService.viewModulesForTenant(argv.tenant)
+    .then((response) => {
+      if (Array.isArray(response)) {
+        response.forEach(mod => console.log(mod));
+      } else {
+        console.log(response);
+      }
+    });
+}
+
+module.exports = {
+  command: 'view',
+  describe: 'View enabled modules for a tenant in Okapi',
+  builder: (yargs) => {
+    yargs
+      .option('test', {
+        type: 'boolean',
+      })
+      .example('$0 mod view --tenant diku', '');
+    return applyOptions(yargs, Object.assign({}, okapiOptions));
+  },
+  handler: mainHandler(viewModuleCommand),
+};

--- a/lib/commands/mod/view.js
+++ b/lib/commands/mod/view.js
@@ -22,13 +22,10 @@ function viewModuleCommand(argv, context) {
 
 module.exports = {
   command: 'view',
-  describe: 'View enabled modules for a tenant in Okapi',
+  describe: 'View enabled module ids for a tenant in Okapi',
   builder: (yargs) => {
     yargs
-      .option('test', {
-        type: 'boolean',
-      })
-      .example('$0 mod view --tenant diku', '');
+      .example('$0 mod view --tenant diku', 'View enabled module ids for tenant diku');
     return applyOptions(yargs, Object.assign({}, okapiOptions));
   },
   handler: mainHandler(viewModuleCommand),

--- a/lib/commands/perm/assign.js
+++ b/lib/commands/perm/assign.js
@@ -51,7 +51,8 @@ module.exports = {
     yargs
       .option('name', permOptions.name)
       .option('user', permOptions.user)
-      .example('$0 perm assign', '');
+      .example('$0 perm assign --name module.hello-world.enabled --user diku_admin', 'Assign permission to user diku_admin')
+      .example('$0 perm view --user jack | $0 perm assign --user jill', 'Assign permissions from user jack to user jill');
     return applyOptions(yargs, Object.assign({}, okapiOptions));
   },
   handler: mainHandler(stdinArrayHandler('name', promptHandler(permOptions, assignPermissionsCommand))),

--- a/lib/commands/perm/assign.js
+++ b/lib/commands/perm/assign.js
@@ -5,7 +5,7 @@ const Okapi = importLazy('../../okapi');
 const PermissionService = importLazy('../../okapi/permission-service');
 const { applyOptions, okapiOptions } = importLazy('../common-options');
 const { promptHandler } = importLazy('../../cli/questions');
-
+const { stdinArrayHandler } = importLazy('../../cli/stdin-handler');
 
 function assignPermissionsCommand(argv, context) {
   // TODO: update aliases
@@ -14,13 +14,19 @@ function assignPermissionsCommand(argv, context) {
   const okapi = new Okapi(argv.okapi, argv.tenant);
   const permissionService = new PermissionService(okapi, context);
 
-  return permissionService.assignPermissionToUser(argv.name, argv.assign)
-    .then((response) => {
-      if (response.alreadyExists) {
-        console.log(`User ${argv.assign} already has permission ${argv.name}`);
-      } else {
-        console.log(`User ${argv.assign} assigned permission ${argv.name}`);
-      }
+  if (!Array.isArray(argv.name)) {
+    argv.name = [argv.name];
+  }
+
+  return permissionService.assignPermissionsToUser(argv.name, argv.assign)
+    .then((responses) => {
+      responses.forEach(response => {
+        if (response.alreadyExists) {
+          console.log(`User ${argv.assign} already has permission ${response.id}`);
+        } else {
+          console.log(`User ${argv.assign} assigned permission ${response.id}`);
+        }
+      });
     });
 }
 
@@ -48,5 +54,5 @@ module.exports = {
       .example('$0 perm assign', '');
     return applyOptions(yargs, Object.assign({}, okapiOptions));
   },
-  handler: mainHandler(promptHandler(permOptions, assignPermissionsCommand)),
+  handler: mainHandler(stdinArrayHandler('name', promptHandler(permOptions, assignPermissionsCommand))),
 };

--- a/lib/commands/workspace.js
+++ b/lib/commands/workspace.js
@@ -76,7 +76,7 @@ function workspaceCommand(argv, context) {
           const platformDirs = dev.validModules.filter(mod => platforms.includes(mod));
           if (platformDirs.length) {
             console.log(`\nPlatforms available: "${platformDirs.join('", "')}"`);
-            console.log('  "cd" into the above dir(s) and run "stripes serve" to start.');
+            console.log('  "cd" into the above dir(s) and run "stripes serve stripes.config.js.local" to start.');
             console.log('  Edit "stripes.config.js.local" to turn modules on or off.');
           }
           const uiMods = dev.validModules.filter(mod => uiModules.includes(mod));

--- a/lib/okapi/module-service.js
+++ b/lib/okapi/module-service.js
@@ -30,6 +30,12 @@ module.exports = class ModuleDescriptorService {
       .then(() => ({ id: moduleDescriptor.id, success: true }));
   }
 
+  viewModulesForTenant(tenant) {
+    return this.okapi.proxy.getModulesForTenant(tenant)
+      .then(response => response.json())
+      .then(data => data.map(mod => mod.id));
+  }
+
   // TODO: Handle this more like upgrading a module
   // Update a Stripes UI module descriptor by first removing any associated tenants
   updateModuleDescriptor(moduleDescriptor) {

--- a/lib/okapi/module-service.js
+++ b/lib/okapi/module-service.js
@@ -46,15 +46,39 @@ module.exports = class ModuleService {
       .catch(resolveIfOkapiSays('module does not exist', { id: moduleDescriptor.id, doesNotExist: true }));
   }
 
-  enableModuleForTenant(moduleDescriptor, tenant) {
-    return this.okapi.proxy.enableModuleForTenant(moduleDescriptor.id, tenant)
-      .then(() => ({ id: moduleDescriptor.id, success: true }))
-      .catch(resolveIfOkapiSays('already provided', { id: moduleDescriptor.id, alreadyExists: true }));
+  enableModuleForTenant(moduleDescriptorId, tenant) {
+    return this.okapi.proxy.enableModuleForTenant(moduleDescriptorId, tenant)
+      .then(() => ({ id: moduleDescriptorId, success: true }))
+      .catch(resolveIfOkapiSays('already provided', { id: moduleDescriptorId, alreadyExists: true }));
   }
 
-  disableModuleForTenant(moduleDescriptor, tenant) {
-    return this.okapi.proxy.disableModuleForTenant(moduleDescriptor.id, tenant)
-      .then(() => ({ id: moduleDescriptor.id, success: true }));
+  enableModulesForTenant(moduleDescriptorIds, tenant) {
+    return moduleDescriptorIds
+      .map(id => (previousResults) => {
+        const results = previousResults || [];
+        return this.enableModuleForTenant(id, tenant).then(result => {
+          results.push(result);
+          return results;
+        });
+      })
+      .reduce((promiseChain, currentFunction) => promiseChain.then(currentFunction), Promise.resolve());
+  }
+
+  disableModuleForTenant(moduleDescriptorId, tenant) {
+    return this.okapi.proxy.disableModuleForTenant(moduleDescriptorId, tenant)
+      .then(() => ({ id: moduleDescriptorId, success: true }));
+  }
+
+  disableModulesForTenant(moduleDescriptorIds, tenant) {
+    return moduleDescriptorIds
+      .map(id => (previousResults) => {
+        const results = previousResults || [];
+        return this.disableModuleForTenant(id, tenant).then(result => {
+          results.push(result);
+          return results;
+        });
+      })
+      .reduce((promiseChain, currentFunction) => promiseChain.then(currentFunction), Promise.resolve());
   }
 
   viewModulesForTenant(tenant) {

--- a/lib/okapi/module-service.js
+++ b/lib/okapi/module-service.js
@@ -87,9 +87,9 @@ module.exports = class ModuleService {
       .then(data => data.map(mod => mod.id));
   }
 
-  installModulesForTenant(modules, tenant) {
-    const modulePayload = modules.map(mod => {
-      return { id: mod, action: 'enable' };
+  installModulesForTenant(moduleDescriptorIds, tenant) {
+    const modulePayload = moduleDescriptorIds.map(id => {
+      return { id, action: 'enable' };
     });
     return this.okapi.proxy.installModulesForTenant(modulePayload, tenant, { simulate: true });
     // .then(() => ({ id: moduleDescriptor.id, success: true }))

--- a/lib/okapi/module-service.js
+++ b/lib/okapi/module-service.js
@@ -6,10 +6,9 @@ const StripesPlatform = require('../platform/stripes-platform');
 // TODO: Export via stripe-core Node API
 const parser = require('@folio/stripes-core/webpack/stripes-module-parser');
 
-module.exports = class ModuleDescriptorService {
-  constructor(okapiRepository, context) {
+module.exports = class ModuleService {
+  constructor(okapiRepository) {
     this.okapi = okapiRepository;
-    this.context = context;
   }
 
   static getModuleDescriptorsFromContext(context, configFile) {

--- a/lib/okapi/module-service.js
+++ b/lib/okapi/module-service.js
@@ -1,10 +1,38 @@
 const { resolveIfOkapiSays } = require('../okapi/okapi-utils');
 const OkapiError = require('./okapi-error');
+const generateModuleDescriptor = require('../cli/generate-module-descriptor');
+const path = require('path');
+const StripesPlatform = require('../platform/stripes-platform');
+// TODO: Export via stripe-core Node API
+const parser = require('@folio/stripes-core/webpack/stripes-module-parser');
 
 module.exports = class ModuleDescriptorService {
   constructor(okapiRepository, context) {
     this.okapi = okapiRepository;
     this.context = context;
+  }
+
+  static getModuleDescriptorsFromContext(context, configFile) {
+    const packageJsons = [];
+
+    if (context.type === 'app') {
+      packageJsons.push(require(path.join(context.cwd, 'package.json'))); // eslint-disable-line
+    } else if (context.type === 'platform') {
+      // Initialize a platform to take aliases, if any, into account
+      const platform = new StripesPlatform(configFile, context);
+      const stripesConfig = platform.getStripesConfig();
+
+      const moduleNames = Object.getOwnPropertyNames(stripesConfig.modules);
+      moduleNames.forEach(moduleName => {
+        // The StripesModuleParser's constructor takes care of locating a module's package.json
+        // TODO: Wrap with try/catch as this could throw a build error
+        const moduleParser = new parser.StripesModuleParser(moduleName, {}, context.cwd, platform.aliases);
+        packageJsons.push(moduleParser.packageJson);
+      });
+    }
+
+    const descriptors = packageJsons.map(packageJson => generateModuleDescriptor(packageJson));
+    return descriptors;
   }
 
   addModuleDescriptor(moduleDescriptor) {

--- a/lib/okapi/module-service.js
+++ b/lib/okapi/module-service.js
@@ -36,6 +36,15 @@ module.exports = class ModuleDescriptorService {
       .then(data => data.map(mod => mod.id));
   }
 
+  installModulesForTenant(modules, tenant) {
+    const modulePayload = modules.map(mod => {
+      return { id: mod, action: 'enable' };
+    });
+    return this.okapi.proxy.installModulesForTenant(modulePayload, tenant, { simulate: true });
+    // .then(() => ({ id: moduleDescriptor.id, success: true }))
+    // .catch(resolveIfOkapiSays('already provided', { id: moduleDescriptor.id, alreadyExists: true }));
+  }
+
   // TODO: Handle this more like upgrading a module
   // Update a Stripes UI module descriptor by first removing any associated tenants
   updateModuleDescriptor(moduleDescriptor) {

--- a/lib/okapi/okapi-repository.js
+++ b/lib/okapi/okapi-repository.js
@@ -32,6 +32,14 @@ function getModulesForTenant(tenant) {
   return okapiClient.get(`/_/proxy/tenants/${tenant}/modules`, noTenantNoToken);
 }
 
+function installModulesForTenant(modulePayload, tenant, options) {
+  let resource = `/_/proxy/tenants/${tenant}/install`;
+  if (options && options.simulate) {
+    resource += '?simulate=true';
+  }
+  return okapiClient.post(resource, modulePayload, noTenantNoToken);
+}
+
 function assignPermissionToUser(permissionName, userId) {
   return okapiClient.post(`/perms/users/${userId}/permissions?indexField=userId`, { permissionName });
 }
@@ -55,6 +63,7 @@ const okapiRoutes = {
     enableModuleForTenant,
     disableModuleForTenant,
     getModulesForTenant,
+    installModulesForTenant,
   },
   perms: {
     assignPermissionToUser,

--- a/lib/okapi/okapi-repository.js
+++ b/lib/okapi/okapi-repository.js
@@ -28,6 +28,10 @@ function disableModuleForTenant(moduleDescriptorId, tenant) {
   return okapiClient.delete(`/_/proxy/tenants/${tenant}/modules/${moduleDescriptorId}`, noTenantNoToken);
 }
 
+function getModulesForTenant(tenant) {
+  return okapiClient.get(`/_/proxy/tenants/${tenant}/modules`, noTenantNoToken);
+}
+
 function assignPermissionToUser(permissionName, userId) {
   return okapiClient.post(`/perms/users/${userId}/permissions?indexField=userId`, { permissionName });
 }
@@ -50,6 +54,7 @@ const okapiRoutes = {
     removeModuleDescriptor,
     enableModuleForTenant,
     disableModuleForTenant,
+    getModulesForTenant,
   },
   perms: {
     assignPermissionToUser,

--- a/lib/okapi/permission-service.js
+++ b/lib/okapi/permission-service.js
@@ -41,13 +41,32 @@ module.exports = class PermissionService {
     });
   }
 
+  assignPermissionToUserId(permissionName, userId) {
+    return this.okapi.perms.assignPermissionToUser(permissionName, userId)
+      .then(() => ({ id: permissionName, success: true }))
+      .catch(resolveIfOkapiSays('already has permission', { id: permissionName, alreadyExists: true }));
+  }
+
   assignPermissionToUser(permissionName, username) {
     // TODO: Validate permission exists
     return this.okapi.users.getUserByUsername(username)
       .then(response => response.json())
-      .then(payload => this.okapi.perms.assignPermissionToUser(permissionName, payload.users[0].id))
-      .then(() => ({ id: permissionName, success: true }))
-      .catch(resolveIfOkapiSays('already has permission', { id: permissionName, alreadyExists: true }));
+      .then(payload => this.assignPermissionToUserId(permissionName, payload.users[0].id));
+  }
+
+  assignPermissionsToUser(permissionNames, username) {
+    return this.okapi.users.getUserByUsername(username)
+      .then(response => response.json())
+      .then(payload => {
+        return permissionNames.map(permissionName => (previousResults) => {
+          const results = previousResults || [];
+          return this.assignPermissionToUserId(permissionName, payload.users[0].id).then(result => {
+            results.push(result);
+            return results;
+          });
+        })
+          .reduce((promiseChain, currentFunction) => promiseChain.then(currentFunction), Promise.resolve());
+      });
   }
 
   viewPermissionsForUser(username) {


### PR DESCRIPTION
This branch started as a prototype to explore working with multiple modules and Okapi in prep for eventual dynamic module/bundle management.  This yielded a few new commands as well as support for standard input.

* New mod commands to generate descriptors and view tenant modules, STCLI-52
* New app perms command to view permissions for an app, STCLI-54
* Support for stdin, added initially to mod enable/disable and perm assign, STCLI-55