### PR TITLE
STCLI-39 Patch global-dirs on Windows with Yarn >=1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * New `mod` commands to generate descriptors and view tenant modules, STCLI-52
 * New `app perms` command to view permissions for an app, STCLI-54
 * Support for stdin, added initially to mod enable/disable and perm assign, STCLI-55
+* Account for new global Yarn directory on Windows with Yarn >=1.5.1, Fixes STLCI-39
 
 
 ## 1.1.0 (https://github.com/folio-org/stripes-cli/tree/v1.1.0) (2018-4-13)

--- a/lib/cli/context.js
+++ b/lib/cli/context.js
@@ -3,7 +3,7 @@ const path = require('path');
 const isInstalledGlobally = require('is-installed-globally');
 // TODO: Yarn 1.5.1 changed global install directory on Windows, 'global-dirs' does not yet reflect this
 // https://github.com/yarnpkg/yarn/pull/5336
-const globalDirs = require('global-dirs');
+const globalDirs = require('./global-dirs');
 const isPathInside = require('is-path-inside');
 
 const cliRoot = path.join(__dirname, '..', '..');

--- a/lib/cli/global-dirs.js
+++ b/lib/cli/global-dirs.js
@@ -1,0 +1,27 @@
+const globalDirs = require('global-dirs');
+const semver = require('semver');
+const childProcess = require('child_process');
+const path = require('path');
+const logger = require('./logger')('global-dirs');
+
+function isYarnVersion(version) {
+  try {
+    const yarnVersion = childProcess.execSync('yarn --version', { encoding: 'utf8' }).trim();
+    logger.log('Yarn version', yarnVersion);
+    return semver.satisfies(yarnVersion, version);
+  } catch (err) {
+    logger.log('Unable to determine Yarn version.', err);
+    return false;
+  }
+}
+
+// Starting with Yarn 1.5.1 the global node_modules path changed on Windows. See STCLI-39.
+// Check the Yarn version and attempt to correct Yarn paths provided by global-dirs.
+if (process.platform === 'win32' && isYarnVersion('>=1.5.1')) {
+  logger.log('Original globalDirs.yarn:', globalDirs.yarn);
+  globalDirs.yarn.packages = path.join(globalDirs.yarn.prefix, 'Data', 'global', 'node_modules');
+  globalDirs.yarn.binaries = path.join(globalDirs.yarn.packages, '.bin');
+  logger.log('Updated globalDirs.yarn:', globalDirs.yarn);
+}
+
+module.exports = globalDirs;

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "resolve-from": "^4.0.0",
     "resolve-pkg": "^1.0.0",
     "rimraf": "^2.6.2",
+    "semver": "^5.5.0",
     "simple-git": "^1.89.0",
     "supports-color": "^4.5.0",
     "update-notifier": "^2.3.0",


### PR DESCRIPTION
This fix attempts to correct outdated Yarn paths reported by global-dirs on Windows.  If this proves successful for Windows users of stripes-cli, this logic could be contributed back to resolving the original issue within global-dirs itself.
