### PR TITLE
STCLI-59 strict option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Account for new global Yarn directory on Windows with Yarn >=1.5.1, Fixes STLCI-39
 * Add `--coverage` option to test karma command, STCLI-53
 * Add junit reporter and headless Chrome to Karma config for CI, STCLI-56
+* Add `--strict` option to mod add and descriptor commands, STCLI-59
 
 
 ## 1.1.0 (https://github.com/folio-org/stripes-cli/tree/v1.1.0) (2018-4-13)

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -587,6 +587,7 @@ Option | Description | Type | Notes
 ---|---|---|---
 `--okapi` | Specify an Okapi URL | string | 
 `--tenant` | Specify a tenant ID | string | 
+`--strict` | Include required interface dependencies | boolean | default: false 
 
 Examples:
 
@@ -713,6 +714,7 @@ Option | Description | Type | Notes
 ---|---|---|---
 `--configFile` | File containing a Stripes tenant configuration (platform context only) | string | 
 `--full` | Return full module descriptor JSON | boolean | default: false 
+`--strict` | Include required interface dependencies | boolean | default: false 
 
 
 Examples:

--- a/lib/commands/mod/add.js
+++ b/lib/commands/mod/add.js
@@ -16,7 +16,7 @@ function addModuleDescriptorCommand(argv, context) {
   const okapi = new Okapi(argv.okapi, argv.tenant);
   const moduleService = new ModuleService(okapi);
 
-  const descriptors = ModuleService.getModuleDescriptorsFromContext(context);
+  const descriptors = ModuleService.getModuleDescriptorsFromContext(context, null, argv.strict);
   return moduleService.addModuleDescriptor(descriptors[0])
     .then((response) => {
       if (response.alreadyExists) {
@@ -33,6 +33,11 @@ module.exports = {
   describe: 'Add an app module descriptor to Okapi',
   builder: (yargs) => {
     yargs
+      .option('strict', {
+        describe: 'Include required interface dependencies',
+        type: 'boolean',
+        default: false,
+      })
       .example('$0 mod add', '');
     return applyOptions(yargs, Object.assign({}, okapiOptions));
   },

--- a/lib/commands/mod/descriptor.js
+++ b/lib/commands/mod/descriptor.js
@@ -4,7 +4,7 @@ const { mainHandler } = importLazy('../../cli/main-handler');
 const ModuleService = importLazy('../../okapi/module-service');
 
 function moduleDescriptorCommand(argv, context) {
-  const descriptors = ModuleService.getModuleDescriptorsFromContext(context, argv.configFile);
+  const descriptors = ModuleService.getModuleDescriptorsFromContext(context, argv.configFile, argv.strict);
 
   if (argv.full) {
     console.log(JSON.stringify(descriptors, null, 2));
@@ -24,6 +24,11 @@ module.exports = {
       })
       .option('full', {
         describe: 'Return full module descriptor JSON',
+        type: 'boolean',
+        default: false,
+      })
+      .option('strict', {
+        describe: 'Include required interface dependencies',
         type: 'boolean',
         default: false,
       })

--- a/lib/okapi/module-service.js
+++ b/lib/okapi/module-service.js
@@ -11,7 +11,7 @@ module.exports = class ModuleService {
     this.okapi = okapiRepository;
   }
 
-  static getModuleDescriptorsFromContext(context, configFile) {
+  static getModuleDescriptorsFromContext(context, configFile, isStrict) {
     const packageJsons = [];
 
     if (context.type === 'app') {
@@ -30,7 +30,7 @@ module.exports = class ModuleService {
       });
     }
 
-    const descriptors = packageJsons.map(packageJson => generateModuleDescriptor(packageJson));
+    const descriptors = packageJsons.map(packageJson => generateModuleDescriptor(packageJson, isStrict));
     return descriptors;
   }
 


### PR DESCRIPTION
This adds the strict option to `mod add` and `mod descriptor` commands.  The value is then passed through module-service and to generateModuleDescriptor() where strict was already taken into account, but not exercised.