### PR TITLE
STCLI-60 stdin fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Add `--coverage` option to test karma command, STCLI-53
 * Add junit reporter and headless Chrome to Karma config for CI, STCLI-56
 * Add `--strict` option to mod add and descriptor commands, STCLI-59
+* Correct get-stdin dependency, fixes STCLI-60
 
 
 ## 1.1.0 (https://github.com/folio-org/stripes-cli/tree/v1.1.0) (2018-4-13)

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "configstore": "^3.1.1",
     "debug": "^3.1.0",
     "find-up": "^2.1.0",
+    "get-stdin": "^6.0.0",
     "global-dirs": "^0.1.1",
     "http-server": "^0.11.1",
     "import-lazy": "^3.1.0",
@@ -61,7 +62,6 @@
     "@folio/eslint-config-stripes": "^1.1.0",
     "chai": "^4.1.2",
     "eslint": "^4.8.0",
-    "get-stdin": "^5.0.1",
     "sinon": "^4.1.4",
     "sinon-chai": "^2.14.0"
   }


### PR DESCRIPTION
The dependency `get-stdin` was incorrectly identified as a dev-dependency excluding it from a non-dev install of the CLI.