### PR TITLE
highlight failed 'git pull' commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for stripes-cli
 
 ## 1.3.0 (IN PROGRESS)
+* Highlight failed git-pull attempts in a dumb-terminal-friendly way.
 
 
 ## [1.2.0](https://github.com/folio-org/stripes-cli/tree/v1.2.0) (2018-06-07)
@@ -16,7 +17,6 @@
 * Add `--strict` option to mod add and descriptor commands, STCLI-59
 * Correct get-stdin dependency, fixes STCLI-60
 * Use Node 8 to be in line with stripes-core requirement
-* Highlight failed git-pull attempts in a dumb-terminal-friendly way.
 
 
 ## [1.1.0](https://github.com/folio-org/stripes-cli/tree/v1.1.0) (2018-04-13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Add `--strict` option to mod add and descriptor commands, STCLI-59
 * Correct get-stdin dependency, fixes STCLI-60
 * Use Node 8 to be in line with stripes-core requirement
+* Highlight failed git-pull attempts in a dumb-terminal-friendly way.
 
 
 ## [1.1.0](https://github.com/folio-org/stripes-cli/tree/v1.1.0) (2018-04-13)

--- a/lib/commands/platform/pull.js
+++ b/lib/commands/platform/pull.js
@@ -40,11 +40,18 @@ function pullRepository(dir) {
         resolve();
       })
       .catch((err) => {
-        console.log(`Not pulled "${dir}"`, err.message || err);
+        let prefix = '*** ';
+        let postfix = '';
+        if (process.env.TERM !== 'dumb') {
+          prefix = '\x1b[31m⚠️  ';
+          postfix = '\x1b[39m';
+        }
+        console.log(`${prefix}Not pulled "${dir}"${postfix}`, err.message || err);
         resolve();
       });
   });
 }
+
 
 function pullCommand(argv, context) {
   if (context.type !== 'workspace' && context.type !== 'platform') {


### PR DESCRIPTION
Add some syntax highlighting to make it more obvious when 'git pull' commands fail, but be careful not to anger those folks who might run this in an emacs terminal emulator. You wouldn't like them when they're angry.