### PR TITLE
Generate HTML coverage report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.3.0 (IN PROGRESS)
 * Highlight failed git-pull attempts in a dumb-terminal-friendly way.
 * Invoke Nightmare tests with ui-testing's copy of test-module, STCLI-5
+* Generate HTML coverage reports with Istanbul
 
 
 ## [1.2.0](https://github.com/folio-org/stripes-cli/tree/v1.2.0) (2018-06-07)

--- a/lib/test/karma-service.js
+++ b/lib/test/karma-service.js
@@ -65,7 +65,7 @@ module.exports = class KarmaService {
         subdir: '.',
         reporters: [
           { type: 'text' },
-          { type: 'lcovonly', file: 'lcov.txt' }
+          { type: 'lcov' }
         ],
         includeAllSources: true,
         check: {


### PR DESCRIPTION
## Purpose
Istanbul can also generate an easy-to-read HTML coverage report that's way nicer to work with than the raw `lcov` data.

With `stripes-components`:
<img width="1210" alt="screen shot 2018-06-15 at 2 10 01 pm" src="https://user-images.githubusercontent.com/230597/41489913-781abfac-70a6-11e8-8bae-58892b17cffc.png">

## Approach
Switch to the `lcov` reporter instead of `lcovonly` reporter.

I didn't know of any particular reason to hardcode the filename to `lcov.txt`, so it'll now be the default, `lcov.info`.