### PR TITLE
STCLI-64 perm unassign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.3.0 (IN PROGRESS)
 * Highlight failed git-pull attempts in a dumb-terminal-friendly way.
 * Invoke Nightmare tests with ui-testing's copy of test-module, STCLI-5
+* Add perm unassign command, STCLI-64
 
 
 ## [1.2.0](https://github.com/folio-org/stripes-cli/tree/v1.2.0) (2018-06-07)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,4 +3,5 @@ buildNPM {
   publishModDescriptor = 'no'
   runLint = 'yes'
   runTest = 'yes'
+  stripesPlatform = 'none'
 }

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -793,6 +793,7 @@ stripes perm <command>
 Sub-commands:
 * `stripes perm assign`
 * `stripes perm create [name]`
+* `stripes perm unassign`
 * `stripes perm view`
 
 
@@ -859,6 +860,30 @@ Assign permissions from user jack to user jill:
 ```
 stripes perm view --user jack | stripes perm assign --user jill
 ```
+
+### `perm unassign` command
+Unassign permissions from a user
+
+Usage:
+```
+stripes perm unassign
+```
+
+Option | Description | Type | Notes
+---|---|---|---
+`--name` | Name of the permission | string | supports stdin
+`--user` | Username to unassign permission from | string |
+`--okapi` | Specify an Okapi URL | string |
+`--tenant` | Specify a tenant ID | string |
+
+
+Examples:
+
+Unassign permission from user diku_admin:
+```
+stripes perm unassign --name module.hello-world.enabled --user diku_admin
+```
+
 
 ### `perm view` command
 

--- a/lib/commands/perm/unassign.js
+++ b/lib/commands/perm/unassign.js
@@ -1,0 +1,54 @@
+const importLazy = require('import-lazy')(require);
+
+const { mainHandler } = importLazy('../../cli/main-handler');
+const Okapi = importLazy('../../okapi');
+const PermissionService = importLazy('../../okapi/permission-service');
+const { applyOptions, okapiOptions } = importLazy('../common-options');
+const { promptHandler } = importLazy('../../cli/questions');
+const { stdinArrayHandler } = importLazy('../../cli/stdin-handler');
+
+function unassignPermissionsCommand(argv, context) {
+  const okapi = new Okapi(argv.okapi, argv.tenant);
+  const permissionService = new PermissionService(okapi, context);
+
+  if (!Array.isArray(argv.name)) {
+    argv.name = [argv.name];
+  }
+
+  return permissionService.unassignPermissionsFromUser(argv.name, argv.user)
+    .then((responses) => {
+      responses.forEach(response => {
+        if (response.alreadySatisfied) {
+          console.log(`User ${argv.user} does not have permission ${response.id}`);
+        } else {
+          console.log(`User ${argv.user} unassigned permission ${response.id}`);
+        }
+      });
+    });
+}
+
+const permOptions = {
+  name: {
+    describe: 'Name of the permission',
+    type: 'string',
+    group: 'Permission Options:',
+  },
+  user: {
+    describe: 'Username to unassign permission from',
+    type: 'string',
+    group: 'Permission Options:',
+  },
+};
+
+module.exports = {
+  command: 'unassign',
+  describe: 'Unassign permissions from a user',
+  builder: (yargs) => {
+    yargs
+      .option('name', permOptions.name)
+      .option('user', permOptions.user)
+      .example('$0 perm unassign --name module.hello-world.enabled --user diku_admin', 'Unassign permission from user diku_admin');
+    return applyOptions(yargs, Object.assign({}, okapiOptions));
+  },
+  handler: mainHandler(stdinArrayHandler('name', promptHandler(permOptions, unassignPermissionsCommand))),
+};

--- a/lib/okapi/okapi-repository.js
+++ b/lib/okapi/okapi-repository.js
@@ -44,6 +44,10 @@ function assignPermissionToUser(permissionName, userId) {
   return okapiClient.post(`/perms/users/${userId}/permissions?indexField=userId`, { permissionName });
 }
 
+function unassignPermissionFromUser(permissionName, userId) {
+  return okapiClient.delete(`/perms/users/${userId}/permissions/${permissionName}?indexField=userId`);
+}
+
 function getUserByUsername(username) {
   return okapiClient.get(`/users?query=username=${username}`);
 }
@@ -68,6 +72,7 @@ const okapiRoutes = {
   perms: {
     assignPermissionToUser,
     getUserPermissions,
+    unassignPermissionFromUser,
   },
   users: {
     getUserByUsername,

--- a/lib/okapi/permission-service.js
+++ b/lib/okapi/permission-service.js
@@ -76,4 +76,25 @@ module.exports = class PermissionService {
       .then(response => response.json())
       .then(data => data.permissionNames);
   }
+
+  unassignPermissionFromUserId(permissionName, userId) {
+    return this.okapi.perms.unassignPermissionFromUser(permissionName, userId)
+      .then(() => ({ id: permissionName, success: true }))
+      .catch(resolveIfOkapiSays('does not contain', { id: permissionName, alreadySatisfied: true }));
+  }
+
+  unassignPermissionsFromUser(permissionNames, username) {
+    return this.okapi.users.getUserByUsername(username)
+      .then(response => response.json())
+      .then(payload => {
+        return permissionNames.map(permissionName => (previousResults) => {
+          const results = previousResults || [];
+          return this.unassignPermissionFromUserId(permissionName, payload.users[0].id).then(result => {
+            results.push(result);
+            return results;
+          });
+        })
+          .reduce((promiseChain, currentFunction) => promiseChain.then(currentFunction), Promise.resolve());
+      });
+  }
 };


### PR DESCRIPTION
This command will unassign permissions from a user.  It supports stdin for working with multiple permissions.  This was to be included in previous work for perm assign, but had been left out.