### PR TITLE
STCLI-69

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Invoke Nightmare tests with ui-testing's copy of test-module, STCLI-5
 * Generate HTML coverage reports with Istanbul
 * Add perm unassign command, STCLI-64
+* Prefer local/aliased stripes-core for Nightmare tests, STCLI-69
 
 
 ## [1.2.0](https://github.com/folio-org/stripes-cli/tree/v1.2.0) (2018-06-07)

--- a/lib/commands/test/nightmare.js
+++ b/lib/commands/test/nightmare.js
@@ -1,7 +1,7 @@
 const importLazy = require('import-lazy')(require);
 
 const { mainHandler } = importLazy('../../cli/main-handler');
-const stripes = importLazy('@folio/stripes-core/webpack/stripes-node-api');
+const StripesCore = importLazy('../../cli/stripes-core');
 const runNightmareTests = importLazy('../../test/run-nightmare');
 const StripesPlatform = importLazy('../../platform/stripes-platform');
 const { applyOptions, serverOptions, okapiOptions, stripesConfigOptions } = importLazy('../common-options');
@@ -27,7 +27,8 @@ function nightmareCommand(argv, context) {
   }
 
   console.log('Waiting for webpack to build...');
-  stripes.serve(platform.getStripesConfig(), Object.assign({}, argv, { webpackOverrides }))
+  const stripes = new StripesCore(context, platform.aliases);
+  stripes.api.serve(platform.getStripesConfig(), Object.assign({}, argv, { webpackOverrides }))
     .then(() => {
       // TODO: Check for webpack errors before running tests
       console.log('Starting Nightmare tests...');


### PR DESCRIPTION
This change allows `stripes test nightmare` to serve the platform using a local or aliased stripes-core, when one is available.  This is consistent with the logic found in `stripes serve` and `stripes build`.