### PR TITLE
STCLI-70: Add new Chrome for Docker custom launcher for Karma

### DIFF
--- a/lib/test/karma-service.js
+++ b/lib/test/karma-service.js
@@ -23,8 +23,15 @@ module.exports = class KarmaService {
 
       customLaunchers: {
         // Custom launcher for CI
-        ChromeDocker: {
+        ChromeHeadlessDocker: {
           base: 'ChromeHeadless',
+          flags: [
+            '--no-sandbox',
+            '--disable-web-security'
+          ]
+        },
+        ChromeDocker: {
+          base: 'Chrome',
           flags: [
             '--no-sandbox',
             '--disable-web-security'


### PR DESCRIPTION
- Rename existing 'ChromeDocker' custom karma browser launcher to 'ChromeHeadlessDocker'.  
- Add new, non-headless 'ChromeDocker' custom launcher with support to run in Docker. 