### PR TITLE
STCLI-61 webpack 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add perm unassign command, STCLI-64
 * Prefer local/aliased stripes-core for Nightmare tests, STCLI-69
 * Include extra modules when generating descriptors for a platform, STCLI-65
+* Upgrade to Webpack 4, STCLI-61
 
 
 ## [1.2.0](https://github.com/folio-org/stripes-cli/tree/v1.2.0) (2018-06-07)

--- a/lib/test/webpack-config.js
+++ b/lib/test/webpack-config.js
@@ -1,20 +1,14 @@
-const webpack = require('webpack');
 const path = require('path');
 
 // TODO: Move this to stripes-core and expose as part of the Stripes Node API
 // Generates a webpack config for Stripes independent of build or serve
 module.exports = function getStripesWebpackConfig(stripeCore, stripesConfig, options) {
-  const StripesConfigPlugin = stripeCore.getCoreModule('webpack/stripes-config-plugin');
-  const StripesBrandingPlugin = stripeCore.getCoreModule('webpack/stripes-branding-plugin');
-  const StripesTranslationPlugin = stripeCore.getCoreModule('webpack/stripes-translations-plugin');
+  const StripesWebpackPlugin = stripeCore.getCoreModule('webpack/stripes-webpack-plugin');
   const applyWebpackOverrides = stripeCore.getCoreModule('webpack/apply-webpack-overrides');
 
   // TODO: Switch between dev and prod files bases on env
   let config = stripeCore.getCoreModule('webpack.config.cli.dev');
-  config.plugins.push(new StripesConfigPlugin(stripesConfig));
-  config.plugins.push(new StripesBrandingPlugin(stripesConfig.branding));
-  config.plugins.push(new StripesTranslationPlugin(stripesConfig));
-  config.plugins.push(new webpack.EnvironmentPlugin(['NODE_ENV']));
+  config.plugins.push(new StripesWebpackPlugin({ stripesConfig }));
   const platformModulePath = path.join(path.resolve(), 'node_modules');
   const coreModulePath = path.join(stripeCore.corePath, 'node_modules');
   config.resolve.modules = ['node_modules', platformModulePath, coreModulePath];

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "simple-git": "^1.89.0",
     "supports-color": "^4.5.0",
     "update-notifier": "^2.3.0",
-    "webpack": "^3.4.1",
+    "webpack": "^4.10.2",
     "webpack-bundle-analyzer": "^2.9.1",
     "yargs": "^10.0.3"
   },


### PR DESCRIPTION
This primarily updates `test/webpack-config.js`, used by Karma tests, to use the new wrapping `StripesWebpackPlugin` rather than adding each Stripes plugin individually.

This config still needs to be moved to stripes-core to avoid going out of sync (STCLI-22).
