### PR TITLE
Update CLI inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Include extra modules when generating descriptors for a platform, STCLI-65
 * Upgrade to Webpack 4, STCLI-61
 * Support running Nightmare tests against an existing instance of FOLIO, STCLI-63
+* Update wildcard in workspace template to consider all workspace directories
 
 
 ## [1.2.0](https://github.com/folio-org/stripes-cli/tree/v1.2.0) (2018-06-07)

--- a/lib/environment/inventory.js
+++ b/lib/environment/inventory.js
@@ -37,6 +37,7 @@ const stripesModules = [
 const platforms = [
   'stripes-sample-platform',
   'folio-testing-platform',
+  'platform-core',
 ];
 
 // Available for cloning

--- a/lib/environment/inventory.js
+++ b/lib/environment/inventory.js
@@ -17,6 +17,7 @@ const uiModules = [
   'ui-finance',
   'ui-orders',
   'ui-calendar',
+  'ui-tags',
 ];
 
 // These modules are candidates for aliases

--- a/resources/workspace/package.json
+++ b/resources/workspace/package.json
@@ -1,8 +1,7 @@
 {
   "private": true,
   "workspaces": [
-      "stripes-*",
-      "ui-*"
+      "*"
   ],
   "dependencies": {
   }


### PR DESCRIPTION
Add `ui-tags` and `platform-core` to the CLI inventory to include them commands like `workspace`, `pull`, and `clean`.

The workspace template has also been updated to consider all directories within, since not all FOLIO projects begin with "ui-" or "stripes-".

