### PR TITLE
STCOR-232 language option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Upgrade to Webpack 4, STCLI-61
 * Support running Nightmare tests against an existing instance of FOLIO, STCLI-63
 * Update wildcard in workspace template to consider all workspace directories
+* Apply a default language to generated tenant config for faster build times, STCOR-232
 
 
 ## [1.2.0](https://github.com/folio-org/stripes-cli/tree/v1.2.0) (2018-06-07)

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -149,6 +149,7 @@ Positional | Description | Type | Notes
 Option | Description | Type | Notes
 ---|---|---|---
 `--hasAllPerms` | Set "hasAllPerms" in Stripes config | boolean |
+`--languages` | Languages to include in tenant build | array |
 `--port` | Development server port | number | default: 3000
 `--host` | Development server host | string |
 `--cache` | Use HardSourceWebpackPlugin cache | boolean |
@@ -200,6 +201,7 @@ Option | Description | Type | Notes
 `--okapi` | Specify an Okapi URL | string |
 `--tenant` | Specify a tenant ID | string |
 `--hasAllPerms` | Set "hasAllPerms" in Stripes config | boolean |
+`--languages` | Languages to include in tenant build | array |
 `--output` | Directory to place build output | string |
 `--sourcemap` | Include sourcemaps in build output | boolean |
 `--analyze` | Run the Webpack Bundle Analyzer after build (launches in browser) | boolean |
@@ -245,6 +247,7 @@ Option | Description | Type | Notes
 `--okapi` | Specify an Okapi URL | string |
 `--tenant` | Specify a tenant ID | string |
 `--hasAllPerms` | Set "hasAllPerms" in Stripes config | boolean |
+`--languages` | Languages to include in tenant build | array |
 
 
 Examples:
@@ -280,6 +283,7 @@ Option | Description | Type | Notes
 `--okapi` | Specify an Okapi URL | string |
 `--tenant` | Specify a tenant ID | string |
 `--hasAllPerms` | Set "hasAllPerms" in Stripes config | boolean |
+`--languages` | Languages to include in tenant build | array |
 `--run` | Name of the test script to run | string |
 `--show` | Show UI and dev tools while running tests | boolean |
 `--url` | Url of FOLIO UI to run tests against | string | 
@@ -325,6 +329,7 @@ Option | Description | Type | Notes
 `--okapi` | Specify an Okapi URL | string |
 `--tenant` | Specify a tenant ID | string |
 `--hasAllPerms` | Set "hasAllPerms" in Stripes config | boolean |
+`--languages` | Languages to include in tenant build | array |
 `--coverage` | Enable Karma coverage reports | boolean |
 `--karma` | Options passed to Karma using dot-notation and camelCase: --karma.browsers=Chrome --karma.singleRun |  |
 
@@ -355,6 +360,8 @@ Option | Description | Type | Notes
 ---|---|---|---
 `--okapi` | Specify an Okapi URL | string |
 `--tenant` | Specify a tenant ID | string |
+`--hasAllPerms` | Set "hasAllPerms" in Stripes config | boolean |
+`--languages` | Languages to include in tenant build | array |
 `--platform` | View development platform status | boolean |
 
 

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -539,6 +539,10 @@ Note: If running the analyzer with aliased modules, duplication is likely.  It i
 
 One quick way to limit the build output, is to limit the number of languages included in the build.  This is done my modifying a tenant's Stripes configuration.  See [filtering translations at build time](https://github.com/folio-org/stripes-core/blob/master/doc/dev-guide.md#filtering-translations-at-build-time) of the Stripes developer guide on how to to this.  The result will not only limit translation files, but also locale assets for `react-intl` and `moment` libraries.
 
+Filtering languages can be done with the CLI by specifying the `languages` option which accepts an array of values.  
+```
+stripes build stripes.config.js --languages en es
+```
 
 ## Viewing diagnostic output
 

--- a/lib/commands/common-options.js
+++ b/lib/commands/common-options.js
@@ -64,6 +64,11 @@ module.exports.stripesConfigOptions = {
     describe: 'Set "hasAllPerms" in Stripes config',
     group: 'Stripes Options:',
   },
+  languages: {
+    type: 'array',
+    describe: 'Languages to include in tenant build',
+    group: 'Stripes Options:',
+  }
 };
 
 module.exports.buildOptions = {

--- a/lib/commands/status.js
+++ b/lib/commands/status.js
@@ -75,7 +75,7 @@ module.exports = {
         describe: 'View development platform status',
         type: 'boolean',
       });
-    return applyOptions(yargs, okapiOptions, stripesConfigOptions);
+    return applyOptions(yargs, Object.assign({}, okapiOptions, stripesConfigOptions));
   },
   handler: mainHandler(statusCommand),
 };

--- a/lib/platform/platform-config.js
+++ b/lib/platform/platform-config.js
@@ -10,6 +10,7 @@ const defaultConfig = {
     logPrefix: '--',
     showPerms: false,
     hasAllPerms: false,
+    languages: ['en'],
   },
   modules: {
   },

--- a/lib/platform/stripes-platform.js
+++ b/lib/platform/stripes-platform.js
@@ -85,6 +85,9 @@ module.exports = class StripesPlatform {
       if (options.hasAllPerms) {
         this.config.config.hasAllPerms = true;
       }
+      if (options.languages) {
+        this.config.config.languages = options.languages;
+      }
     }
   }
 


### PR DESCRIPTION
The number of available translation strings has grown.  This has contributed to increased build times.  One quick way to reduce build times is to build with only one language by specifying a language in `stripes.config.js`.  As reported in STCOR-232,  build times for folio-testing-platform can be reduced by 28% with this technique.

This change to the CLI defines a single language default, `en`, whenever the CLI generates a tenant config.  This applies to apps built in isolation.  When building a platform, the languages array (or absence of it) in a`stripes.config.js` is still respected.

Also included is a command line `--languages` option to override the `en` default or value specified in `stripes.config.js`.  Like any other CLI option, this can be persisted in a `.stripesclirc` config file for convenience.

See STCOR-232 for more details.