### PR TITLE
STCLI-74 Simplify webpack config when testing stripes-components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Support running Nightmare tests against an existing instance of FOLIO, STCLI-63
 * Update wildcard in workspace template to consider all workspace directories
 * Apply a default language to generated tenant config for faster build times, STCOR-232
+* Simplify webpack config when testing stripes-components to reduce build time, STCLI-74
 
 
 ## [1.2.0](https://github.com/folio-org/stripes-cli/tree/v1.2.0) (2018-06-07)

--- a/lib/commands/test/karma.js
+++ b/lib/commands/test/karma.js
@@ -12,7 +12,7 @@ function karmaCommand(argv, context) {
     process.env.NODE_ENV = 'test';
   }
 
-  if (context.type !== 'app') {
+  if (context.type !== 'app' && context.type !== 'components') {
     console.log('Tests are only supported within an app context.');
     return;
   }
@@ -26,7 +26,12 @@ function karmaCommand(argv, context) {
 
   console.log('Starting Karma tests...');
   const stripes = new StripesCore(context, platform.aliases);
-  const webpackConfig = stripes.getStripesWebpackConfig(platform.getStripesConfig(), Object.assign({}, argv, { webpackOverrides }));
+  const webpackConfigOptions = {
+    coverage: argv.coverage,
+    omitPlatform: context.type === 'components',
+    webpackOverrides,
+  };
+  const webpackConfig = stripes.getStripesWebpackConfig(platform.getStripesConfig(), webpackConfigOptions);
 
   const karmaService = new KarmaService(context.cwd);
   karmaService.runKarmaTests(webpackConfig, argv.karma);

--- a/lib/test/webpack-config.js
+++ b/lib/test/webpack-config.js
@@ -8,7 +8,14 @@ module.exports = function getStripesWebpackConfig(stripeCore, stripesConfig, opt
 
   // TODO: Switch between dev and prod files bases on env
   let config = stripeCore.getCoreModule('webpack.config.cli.dev');
-  config.plugins.push(new StripesWebpackPlugin({ stripesConfig }));
+
+  // Omit all other entry points and don't bother adding stripes plugins when tests don't require a platform
+  if (options.omitPlatform) {
+    config.entry = ['webpack-hot-middleware/client'];
+  } else {
+    config.plugins.push(new StripesWebpackPlugin({ stripesConfig }));
+  }
+
   const platformModulePath = path.join(path.resolve(), 'node_modules');
   const coreModulePath = path.join(stripeCore.corePath, 'node_modules');
   config.resolve.modules = ['node_modules', platformModulePath, coreModulePath];


### PR DESCRIPTION
As discovered in review of STCLI-74, a portion of the webpack configuration is unnecessary for running stripes-components tests in isolation.  Omitting unused entry points and plugins reduces build time significantly.  This change uses a new stripes.type of "components" to identify when the limited build configuration should be invoked.  A couple modifications to stripes-components are necessary to take advantage of this.
