### PR TITLE
STCLI-76 platform tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Update wildcard in workspace template to consider all workspace directories
 * Apply a default language to generated tenant config for faster build times, STCOR-232
 * Simplify webpack config when testing stripes-components to reduce build time, STCLI-74
+* Improve support for running tests against a platform and its apps, STCLI-76
 
 
 ## [1.2.0](https://github.com/folio-org/stripes-cli/tree/v1.2.0) (2018-06-07)

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -286,26 +286,34 @@ Option | Description | Type | Notes
 `--languages` | Languages to include in tenant build | array |
 `--run` | Name of the test script to run | string |
 `--show` | Show UI and dev tools while running tests | boolean |
-`--url` | Url of FOLIO UI to run tests against | string | 
+`--url` | URL of FOLIO UI to run tests against | string | 
+`--local` | Shortcut for --url http://localhost:3000 | boolean | defaults to --host and --port
 `--uiTest` | Additional options for ui-testing framework |  |
 
 
 Examples:
 
-Serve app and run it's demo.js Nightmare tests:
+Serve app or platform and run all of its Nightmare tests:
+```
+stripes test nightmare
+```
+Serve app or platform and run its demo.js Nightmare tests:
 ```
 stripes test nightmare --run demo
 ```
+Run Nightmare tests against a locally hosted instance of FOLIO:
+```
+stripes test nightmare --local
+```
+Run Nightmare tests against an external instance of FOLIO:
+```
+stripes test nightmare --url http://folio-testing.aws.indexdata.com/
+```
+Specify a username via ui-testing's test-module CLI options:
+```
+stripes test nightmare --uiTest.username admin
+```
 
-Run Nightmare tests against an existing instance of FOLIO:
-```
-stripes test nightmare --run demo --url http://localhost:3000
-```
-
-Specify a username via ui-testing options:
-```
-stripes test nightmare --run demo --uiTest.username admin
-```
 
 ### `test karma` command
 Run the current app module's Karma tests

--- a/lib/commands/test/nightmare.js
+++ b/lib/commands/test/nightmare.js
@@ -25,6 +25,15 @@ function nightmareCommand(argv, context) {
     webpackOverrides.push(context.plugin.beforeBuild(argv));
   }
 
+  // Convenience to refer to a build running on localhost
+  if (argv.local) {
+    if (argv.host && argv.port) {
+      argv.url = `http://${argv.host}:${argv.port}`;
+    } else {
+      argv.url = 'http://localhost:3000';
+    }
+  }
+
   const setup = () => {
     if (argv.url) {
       console.log(`Using URL ${argv.url}`);
@@ -73,15 +82,23 @@ module.exports = {
         type: 'boolean',
       })
       .option('url', {
-        describe: 'Url of FOLIO UI to run tests against',
+        describe: 'URL of FOLIO UI to run tests against',
         type: 'string',
+      })
+      .option('local', {
+        describe: 'Shortcut for --url http://localhost:3000',
+        type: 'boolean',
+        default: undefined,
+        conflicts: 'url',
       })
       .option('uiTest', {
         describe: 'Additional options for ui-testing framework',
       })
-      .example('$0 test nightmare --run demo', 'Serve app and run it\'s demo.js Nightmare tests')
-      .example('$0 test nightmare --run demo --url http://localhost:3000', 'Run Nightmare tests against an existing instance of FOLIO')
-      .example('$0 test nightmare --run demo --uiTest.username admin', 'Specify a username via ui-testing options');
+      .example('$0 test nightmare', 'Serve app or platform and run all of its Nightmare tests')
+      .example('$0 test nightmare --run demo', 'Serve app or platform and run its demo.js Nightmare tests')
+      .example('$0 test nightmare --local', 'Run Nightmare tests against a locally hosted instance of FOLIO')
+      .example('$0 test nightmare --url http://folio-testing.aws.indexdata.com/', 'Run Nightmare tests against an external instance of FOLIO')
+      .example('$0 test nightmare --uiTest.username admin', 'Specify a username via ui-testing\'s test-module CLI options');
     return applyOptions(yargs, Object.assign({}, serverOptions, okapiOptions, stripesConfigOptions));
   },
   handler: mainHandler(nightmareCommand),

--- a/lib/test/nightmare-service.js
+++ b/lib/test/nightmare-service.js
@@ -1,6 +1,9 @@
 const runProcess = require('../run-process');
 const path = require('path');
+const { uiModules } = require('../environment/inventory');
 const logger = require('../cli/logger')('nightmare');
+
+const workingDirectoryToken = 'WD'; // instructs ui-testing to run tests against the working directory
 
 module.exports = class NightmareService {
   constructor(cliContext, options) {
@@ -9,13 +12,50 @@ module.exports = class NightmareService {
     this.runProcess = runProcess;
   }
 
+  /*
+    TODO: Transfer to CLI documents
+
+    ui-testing's test-module CLI accepts "--run" values in the following compound forward-slash and colon separated format:
+
+      --run moduleA/moduleB:testX/moduleC:testY
+
+    * Forward-slashes, "/", separate modules and modules:testScript pairs
+    * Modules can be referenced alone, as in "moduleA" above, referring to @folio/moduleA. In this case, the test-module CLI will invoke all the module's test via index named, "@folio/moduleA/test/ui-testing/test.js"
+    * When paired with a test script name, as in "moduleB:testX", ui-testing's test-module CLI will invoke just the test script found in "@folio/moduleB/test/ui-testing/testX.js"
+
+    Stripes-CLI introduces a new concept of working directory, allowing for a module or platform to be specified by path rather than @folio-scoped name.
+    This enables the CLI to invoke tests from within the current module or platform directory.  The "WD" token instructs test-module to apply the working directory, rather than @folio scope.
+
+      --run WD/WD:testZ/moduleA/moduleB:testX/moduleC:testY
+
+    Stripes-CLI defaults to the working directory context, applying "WD" token to each segment automatically.
+    The token will not be applied when already present, a colon is present, or the segment matches a ui-module name.
+    To observe the generated "--run" value passed to ui-testing, enable DEBUG=stripes-cli:nightmare
+  */
+  _getRunValue(options) {
+    const applyWorkingDirectoryToken = (runSegment) => {
+      if (runSegment.includes(':') || runSegment.startsWith(workingDirectoryToken) || uiModules.includes(`ui-${runSegment}`)) {
+        return runSegment;
+      }
+      return `${workingDirectoryToken}:${runSegment}`;
+    };
+
+    if (options.uiTest && options.uiTest.run) {
+      return options.uiTest.run; // Pass a raw --run value to ui-testing
+    } else if (options.run) {
+      return options.run.split('/').map(applyWorkingDirectoryToken).join('/'); // Parse --run and apply token as needed
+    } else {
+      return workingDirectoryToken; // No --run specified, apply token
+    }
+  }
+
   prepareTestArgs(options) {
     const serveUrl = `http://${options.host || 'localhost'}:${options.port || '3000'}`;
 
     this.testArgs = [
       '--workingDirectory', this.cwd,
       '--url', options.url || serveUrl,
-      '--run', options.run ? `WD:${options.run}` : 'WD', // Here 'WD' instructs ui-testing to run tests against the working directory
+      '--run', this._getRunValue(options),
     ];
 
     if (options.show) {

--- a/test/test/nightmare-service.spec.js
+++ b/test/test/nightmare-service.spec.js
@@ -58,6 +58,41 @@ describe('The nightmare-service', function () {
       expectOrdered(this.sut.testArgs, ['--run', 'WD']);
     });
 
+    it('does not apply working directory token when token is already present', function () {
+      const options = { run: 'WD:110-auth-success' };
+      this.sut = new NightmareService(context, options);
+      expectOrdered(this.sut.testArgs, ['--run', 'WD:110-auth-success']);
+    });
+
+    it('does not apply working directory token when a ui-module is provided', function () {
+      const options = { run: 'users' };
+      this.sut = new NightmareService(context, options);
+      expectOrdered(this.sut.testArgs, ['--run', 'users']);
+    });
+
+    it('does not apply working directory token when module:testScript format is provided', function () {
+      const options = { run: 'moduleA:testX' };
+      this.sut = new NightmareService(context, options);
+      expectOrdered(this.sut.testArgs, ['--run', 'moduleA:testX']);
+    });
+
+    it('generates multiple --run segments of different conditions', function () {
+      const options = { run: 'WD/WD:testX/testY/users/moduleA:testZ' };
+      this.sut = new NightmareService(context, options);
+      expectOrdered(this.sut.testArgs, ['--run', 'WD/WD:testX/WD:testY/users/moduleA:testZ']);
+    });
+
+    it('prefers --uiTest.run when supplied', function () {
+      const options = {
+        run: 'not-this',
+        uiTest: {
+          run: 'users:new_user'
+        }
+      };
+      this.sut = new NightmareService(context, options);
+      expectOrdered(this.sut.testArgs, ['--run', 'users:new_user']);
+    });
+
     it('generates --show and --devTools', function () {
       const options = { show: true };
       this.sut = new NightmareService(context, options);


### PR DESCRIPTION
Improve support for invoking platform tests via the CLI by conditionally applying workingDirectory token to each --run segment.  This allows for a platform to invoke regression tests for its apps within.