### PR TITLE
STCLI-77 Check for platform first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Apply a default language to generated tenant config for faster build times, STCOR-232
 * Simplify webpack config when testing stripes-components to reduce build time, STCLI-74
 * Improve support for running tests against a platform and its apps, STCLI-76
+* Check for platform first when generating module descriptors, fixes STCLI-77
 
 
 ## [1.2.0](https://github.com/folio-org/stripes-cli/tree/v1.2.0) (2018-06-07)

--- a/lib/okapi/module-service.js
+++ b/lib/okapi/module-service.js
@@ -17,9 +17,7 @@ module.exports = class ModuleService {
   static getModuleDescriptorsFromContext(context, configFile, isStrict) {
     const packageJsons = [];
 
-    if (context.type === 'app') {
-      packageJsons.push(require(path.join(context.cwd, 'package.json'))); // eslint-disable-line
-    } else if (context.type === 'platform') {
+    if (context.type === 'platform') {
       // Initialize a platform to take aliases, if any, into account
       const platform = new StripesPlatform(configFile, context);
       const stripesConfig = platform.getStripesConfig();
@@ -40,6 +38,8 @@ module.exports = class ModuleService {
           }
         }
       });
+    } else {
+      packageJsons.push(require(path.join(context.cwd, 'package.json'))); // eslint-disable-line
     }
 
     const descriptors = packageJsons.map(packageJson => generateModuleDescriptor(packageJson, isStrict));


### PR DESCRIPTION
This fix allows non-app stripes.types like settings or plugin to generate module descriptors in isolation via the CLI.