### PR TITLE
STCLI-82 app create in workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Simplify webpack config when testing stripes-components to reduce build time, STCLI-74
 * Improve support for running tests against a platform and its apps, STCLI-76
 * Check for platform first when generating module descriptors, fixes STCLI-77
+* Support `app create` from within a workspace, STCLI-82
 
 
 ## [1.2.0](https://github.com/folio-org/stripes-cli/tree/v1.2.0) (2018-06-07)

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -16,6 +16,7 @@ Note: When serving or building an existing app module that has dependencies on u
     * [CLI Context](#cli-context)
     * [Platforms](#platforms)
     * [Aliases](#aliases)
+* [Development prerequisites](#development-prerequisites)
 * [App development](#app-development)
     * [Creating your app](#creating-your-app)
     * [Assigning permissions](#assigning-permissions)
@@ -216,12 +217,31 @@ There are two methods of adding aliases in the CLI:
 
 1) `.stripesclirc` file - Any aliases defined in a CLI configuration file apply to commands run from the directory containing `.stripesclirc` file.  Use the configuration file when adding aliases in bulk or looking for a consistent set of alias. See the [CLI configuration](#configuration) for more information.
 
+## Development prerequisites
+
+The subsequent development sections assume an existing Okapi backend, such as the [FOLIO testing-backend](https://app.vagrantup.com/folio/boxes/testing-backend) Vagrant box, is installed and running locally for front-end development.  With Vagrant installed, you can set up FOLIO testing-backend with the following commands:
+```
+$ mkdir testing-backend
+$ cd testing-backend
+$ vagrant init folio/testing-backend
+$ vagrant up
+```
+The FOLIO testing-backend vagrant box includes the default tenant, "diku".  See [this stripes-core document](https://github.com/folio-org/stripes-core/blob/master/doc/new-development-setup.md#update-your-vm) for information updating your Vagrant box.
+
+As an alternative to using a local Vagrant box for Okapi, you can develop against an external Okapi instance.  To do this, specify the URL of your Okapi using the `--okapi` option with each command.  This can also be passed via a `.stripesclirc` [configuration file](#configuration).
+
+```json
+{
+  "okapi": "http://your-okapi-host:and-port",
+  "tenant": "your-tenant-id"
+}
+```
 
 ## App development
 
 As a UI app developer, it is often preferred to develop your app independent from an entire platform.  This allows you to focus on your app's own code and not worry about how it is built or integrated within FOLIO.  The Stripes CLI provides all the necessary configuration to develop both new and existing apps in isolation.
 
-Prerequisites:  The following assumes an existing Okapi backend, such as the FOLIO testing-backend Vagrant box, is installed and running locally on your development.  See (TODO: link here) on how to setup a FOLIO testing-backend.
+Prerequisites:  An Okapi backend is required. See [development prerequisites](#development-prerequisites)
 
 ### Creating your app
 
@@ -369,7 +389,7 @@ Note: When adding an alias via the `alias add` command, the alias is considered 
 
 When developing multiple Stripes apps and/or core modules at the same time, it is often desired to work with a platform containing most or all of the available FOLIO Stripes modules.  See [new development setup](https://github.com/folio-org/stripes-core/blob/master/doc/new-development-setup.md) in stripes-core for more details.  The Stripes CLI provides commands to simplify the creation of such platforms, consolidating several of the steps.
 
-Prerequisites:  The following assumes an existing Okapi backend, such as the FOLIO testing-backend Vagrant box, is installed and running locally on your development.  See (TODO: link here) on how to setup a FOLIO testing-backend.
+Prerequisites:  An Okapi backend is required. See [development prerequisites](#development-prerequisites)
 
 ### Environment setup
 

--- a/lib/commands/app/create.js
+++ b/lib/commands/app/create.js
@@ -7,32 +7,37 @@ const { promptHandler } = importLazy('../../cli/questions');
 const addModCommand = importLazy('../mod/add');
 const enableModCommand = importLazy('../mod/enable');
 const assignPermCommand = importLazy('../perm/assign');
+const path = importLazy('path');
 
 function createAppCommand(argv, context) {
   let appData;
+  const isWorkspace = context.type === 'workspace';
 
   // TODO: Verify destination folder
-  if (context.type !== 'empty') {
+  if (context.type !== 'empty' && !isWorkspace) {
     console.log('Existing package.json found. Nothing created.');
-    return;
+    return Promise.resolve();
   }
 
   console.log('Creating app...');
-  createApp(argv.name, argv.desc)
+  return createApp.createApp(argv.name, argv.desc)
     .then((data) => {
       appData = data;
       if (argv.install) {
         console.log('Installing dependencies...');
-        return yarn.install(appData.appDir);
+        const targetDir = isWorkspace ? context.cwd : path.resolve(context.cwd, appData.appDir);
+        return yarn.install(targetDir);
       } else {
         return { isInstalled: false, appDir: appData.appDir };
       }
     })
     .then((result) => {
       if (result.isInstalled) {
-        console.log(`"cd ${result.appDir}" and then "stripes serve" to run your new app`);
+        console.log(`"cd ${appData.appDir}" and then "stripes serve" to run your new app`);
+      } else if (isWorkspace) {
+        console.log(`"yarn install", "cd ${appData.appDir}", and then "stripes serve" to run your new app`);
       } else {
-        console.log(`"cd ${result.appDir}", "yarn install", and then "stripes serve" to run your new app`);
+        console.log(`"cd ${appData.appDir}", "yarn install", and then "stripes serve" to run your new app`);
       }
       return Promise.resolve();
     })
@@ -53,11 +58,10 @@ function createAppCommand(argv, context) {
           .then(() => enableModCommand.handler(argv))
           .then(() => {
             // Assign the new permission to a user
-            argv.name = `module.${appData.appName}.enabled`;
-            return assignPermCommand.handler(argv);
-          })
-          .then(() => {
-            argv.name = `settings.${appData.appName}.enabled`;
+            argv.name = [
+              `module.${appData.appName}.enabled`,
+              `settings.${appData.appName}.enabled`,
+            ];
             return assignPermCommand.handler(argv);
           });
       }

--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -24,7 +24,7 @@ function appDefaults(inputName, inputDescription) {
   return defaults;
 }
 
-module.exports = function createApp(appName, appDescription) {
+function createApp(appName, appDescription) {
   const data = appDefaults(appName, appDescription);
   console.log(JSON.stringify(data, null, 2));
   const templateDir = path.join(__dirname, '..', 'resources/ui-app');
@@ -36,4 +36,9 @@ module.exports = function createApp(appName, appDescription) {
   }).catch((err) => {
     console.log(err.stack);
   });
+}
+
+module.exports = {
+  appDefaults,
+  createApp,
 };

--- a/test/commands/app/create.spec.js
+++ b/test/commands/app/create.spec.js
@@ -1,0 +1,147 @@
+const expect = require('chai').expect;
+
+const context = require('../../../lib/cli/context');
+const yarn = require('../../../lib/yarn');
+const createApp = require('../../../lib/create-app');
+const appCreateCommand = require('../../../lib/commands/app/create');
+const addModCommand = require('../../../lib/commands/mod/add');
+const enableModCommand = require('../../../lib/commands/mod/enable');
+const assignPermissionCommand = require('../../../lib/commands/perm/assign');
+
+
+const yarnStub = () => Promise.resolve({
+  isInstalled: true,
+  appDir: 'ui-hello-world',
+});
+const createAppStub = () => Promise.resolve({
+  appName: 'hello-world',
+  appDir: 'ui-hello-world',
+});
+const addModStub = () => Promise.resolve({
+  success: true,
+  id: 'hello-world'
+});
+
+describe('The app create command', function () {
+  beforeEach(function () {
+    this.argv = {
+      name: 'hello world',
+      desc: 'my first app',
+    };
+    this.context = {
+      type: 'empty',
+      cwd: '/path/to/working/directory'
+    };
+    this.sut = appCreateCommand;
+    this.sandbox.stub(context, 'getContext').returns(this.context);
+    this.sandbox.stub(createApp, 'createApp').callsFake(createAppStub);
+    this.sandbox.stub(yarn, 'install').callsFake(yarnStub);
+    this.sandbox.stub(addModCommand, 'handler').callsFake(addModStub);
+    this.sandbox.stub(enableModCommand, 'handler').callsFake(() => Promise.resolve());
+    this.sandbox.stub(assignPermissionCommand, 'handler').callsFake(() => Promise.resolve());
+    this.sandbox.spy(console, 'log');
+  });
+
+  it('calls create app service', function (done) {
+    this.sut.handler(this.argv)
+      .then(() => {
+        expect(createApp.createApp).to.have.been.calledWith('hello world', 'my first app');
+        done();
+      });
+  });
+
+  it('does not create an app when run from within an app', function (done) {
+    this.context.type = 'app';
+    this.sut.handler(this.argv)
+      .then(() => {
+        expect(createApp.createApp).not.to.have.been.called;
+        expect(console.log).to.have.been.calledWithMatch('Nothing created');
+        done();
+      });
+  });
+
+  it('yarn installs dependencies in the app directory', function (done) {
+    this.argv.install = true;
+    this.sut.handler(this.argv)
+      .then(() => {
+        expect(yarn.install).to.have.been.calledWith('/path/to/working/directory/ui-hello-world');
+        expect(console.log).to.have.been.calledWithMatch('then "stripes serve" to run your new app');
+        done();
+      });
+  });
+
+  it('yarn installs dependencies in the workspace directory', function (done) {
+    this.argv.install = true;
+    this.context.type = 'workspace';
+    this.sut.handler(this.argv)
+      .then(() => {
+        expect(yarn.install).to.have.been.calledWith('/path/to/working/directory');
+        expect(console.log).to.have.been.calledWithMatch('then "stripes serve" to run your new app');
+        done();
+      });
+  });
+
+  it('reports install instructions for --no-install', function (done) {
+    this.argv.install = false;
+    this.sut.handler(this.argv)
+      .then(() => {
+        expect(yarn.install).not.to.have.been.called;
+        expect(console.log).to.have.been.calledWithMatch('"cd ui-hello-world", "yarn install",');
+        done();
+      });
+  });
+
+  it('reports workspace install instructions for --no-install', function (done) {
+    this.argv.install = false;
+    this.context.type = 'workspace';
+    this.sut.handler(this.argv)
+      .then(() => {
+        expect(yarn.install).not.to.have.been.called;
+        expect(console.log).to.have.been.calledWithMatch('"yarn install", "cd ui-hello-world",');
+        done();
+      });
+  });
+
+  it('calls "mod add" handler to post the new ui-app module descriptor to okapi', function (done) {
+    this.argv.assign = 'username';
+    this.sut.handler(this.argv)
+      .then(() => {
+        expect(addModCommand.handler).to.have.been.calledOnce;
+        expect(console.log).to.have.been.calledWithMatch('added to Okapi');
+        done();
+      });
+  });
+
+  it('reports when the new ui-app module descriptor already exists', function (done) {
+    this.argv.assign = 'username';
+    addModCommand.handler.restore();
+    this.sandbox.stub(addModCommand, 'handler').callsFake(() => Promise.resolve({ alreadyExists: true }));
+    this.sut.handler(this.argv)
+      .then(() => {
+        expect(addModCommand.handler).to.have.been.calledOnce;
+        expect(console.log).to.have.been.calledWithMatch('Okapi already has a module with id');
+        done();
+      });
+  });
+
+  it('calls "mod enable" handler to enable the new ui-app module for a tenant', function (done) {
+    this.argv.assign = 'username';
+    this.sut.handler(this.argv)
+      .then(() => {
+        expect(enableModCommand.handler).to.have.been.calledOnce;
+        done();
+      });
+  });
+
+  it('calls "perm assign" handler assign new ui-app permissions to a user', function (done) {
+    this.argv.assign = 'username';
+    this.sut.handler(this.argv)
+      .then(() => {
+        expect(assignPermissionCommand.handler).to.have.been.calledWithMatch({
+          assign: 'username',
+          name: ['module.hello-world.enabled', 'settings.hello-world.enabled'],
+        });
+        done();
+      });
+  });
+});


### PR DESCRIPTION
This change updates "app create" command to support use from within a workspace.  The primary difference is in where the subsequent "yarn install" is invoked from.  Tests have been added to cover this command.  STCLI-82

Updates to the user guide are also included to more clearly identify app/platform development prerequisites, STCLI-81
