### PR TITLE
Replace karma-coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-cli
 
+## [1.4.0] (IN PROGRESS)
+* Switched from `karma-coverage` to `karma-coverage-istanbul-reporter`
+
+
 ## [1.3.0](https://github.com/folio-org/stripes-cli/tree/v1.3.0) (2018-08-07)
 
 * Highlight failed git-pull attempts in a dumb-terminal-friendly way.

--- a/lib/test/karma-service.js
+++ b/lib/test/karma-service.js
@@ -67,15 +67,10 @@ module.exports = class KarmaService {
         'karma-mocha-reporter',
       ],
 
-      coverageReporter: {
+      coverageIstanbulReporter: {
         dir: 'artifacts/coverage',
-        subdir: '.',
-        reporters: [
-          { type: 'text' },
-          { type: 'lcov' }
-        ],
-        includeAllSources: true,
-        check: {
+        reports: ['text-summary', 'lcov'],
+        thresholds: {
           // Thresholds under which karma will return failure
           // Modules are expected to define their own values in karma.conf.js
           global: {},
@@ -93,8 +88,8 @@ module.exports = class KarmaService {
 
     if (karmaOptions.coverage) {
       logger.log('Enabling coverage');
-      karmaConfig.reporters.push('coverage');
-      karmaConfig.plugins.push('karma-coverage');
+      karmaConfig.reporters.push('coverage-istanbul');
+      karmaConfig.plugins.push('karma-coverage-istanbul-reporter');
     }
 
     if (karmaConfig.reporters.includes('junit')) {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "just-pascal-case": "^1.0.0",
     "karma": "^2.0.2",
     "karma-chrome-launcher": "^2.2.0",
-    "karma-coverage": "^1.1.1",
+    "karma-coverage-istanbul-reporter": "^2.0.1",
     "karma-junit-reporter": "^1.2.0",
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",

--- a/test/test/karma-service.spec.js
+++ b/test/test/karma-service.spec.js
@@ -49,8 +49,8 @@ describe('The karma-service', function () {
     it('enables the coverage reporter', function () {
       this.karmaOptions.coverage = true;
       const karmaConfig = this.sut.generateKarmaConfig(webpackStub, this.karmaOptions);
-      expect(karmaConfig).to.have.property('reporters').to.be.an('array').that.includes('coverage');
-      expect(karmaConfig).to.have.property('plugins').to.be.an('array').that.includes('karma-coverage');
+      expect(karmaConfig).to.have.property('reporters').to.be.an('array').that.includes('coverage-istanbul');
+      expect(karmaConfig).to.have.property('plugins').to.be.an('array').that.includes('karma-coverage-istanbul-reporter');
     });
 
     it('applies a local karma config', function () {
@@ -66,7 +66,7 @@ describe('The karma-service', function () {
       };
 
       const karmaConfig = this.sut.generateKarmaConfig(webpackStub, this.karmaOptions);
-      expect(karmaConfig).to.have.property('coverageReporter').with.property('check').with.deep.property('global', globalExpected);
+      expect(karmaConfig).to.have.property('coverageIstanbulReporter').with.property('thresholds').with.deep.property('global', globalExpected);
     });
   });
 });

--- a/test/test/karma.conf.js
+++ b/test/test/karma.conf.js
@@ -1,5 +1,5 @@
 module.exports = (config) => {
-  config.coverageReporter.check.global = {
+  config.coverageIstanbulReporter.thresholds.global = {
     statements: 95,
     branches: 85,
     functions: 95,


### PR DESCRIPTION
`karma-coverage` still depends on the deprecated [`istanbul`](https://github.com/gotwarlost/istanbul), which hasn't been worked on in two years.

`karma-coverage-istanbul-reporter` switches to using the actively maintained [`istanbul-api`](https://github.com/istanbuljs/istanbuljs) package (used by `nyc`).