### PR TITLE
STCLI-89 spawn on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Switched from `karma-coverage` to `karma-coverage-istanbul-reporter`
 * Resolve issue causing nightmare command to throw an error even when tests pass, fixes STCLI-86
 * STCLI-88 resolved. Resolved an issue where command test nightmare would not return process error when failing
+* Enable shell when spawning child process on Windows, fixes STCLI-89
+
 
 ## [1.3.0](https://github.com/folio-org/stripes-cli/tree/v1.3.0) (2018-08-07)
 

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -1,6 +1,8 @@
 # Stripes CLI Troubleshooting
 
-This page contains troubleshooting suggestions and known issues for the CLI.  Refer to [stripes-core's troubleshooting guide](https://github.com/folio-org/stripes-core/blob/master/doc/troubleshooting.md) for more.
+This page contains troubleshooting suggestions and known issues for the CLI.  Refer to [stripes-core's troubleshooting guide](https://github.com/folio-org/stripes-core/blob/master/doc/troubleshooting.md) for general Stripes troubleshooting.
+
+Also refer to the [STCLI project](https://issues.folio.org/browse/STCLI) in the [FOLIO issue tracker](https://dev.folio.org/guidelines/issue-tracker) to review open bugs that may contain relevant notes or workarounds.
 
 
 ## My new Stripes UI app does not show up!

--- a/lib/run-process.js
+++ b/lib/run-process.js
@@ -9,6 +9,10 @@ module.exports = function runProcess(script, args, options) {
     stdio: 'inherit',
   };
 
+  if (process.platform === 'win32') {
+    defaults.shell = true;
+  }
+
   return new Promise((resolve, reject) => {
     logger.log('spawn child process', script);
     logger.log('child process args', args);

--- a/lib/run-process.js
+++ b/lib/run-process.js
@@ -23,6 +23,10 @@ module.exports = function runProcess(script, args, options) {
           reject(error);
         }
         resolve();
+      })
+      .on('error', (error) => {
+        logger.log('child process failed');
+        reject(error);
       });
   });
 };


### PR DESCRIPTION
Node's child process .spawn is unable to invoke batch files on Windows without a shell.  This prevents the CLI from invoking Mocha.  This fix enables spawn's .shell option.