### PR TITLE
STCLI-92 stripes testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Resolve issue causing nightmare command to throw an error even when tests pass, fixes STCLI-86
 * STCLI-88 resolved. Resolved an issue where command test nightmare would not return process error when failing
 * Enable shell when spawning child process on Windows, fixes STCLI-89
+* Replace `ui-testing#framework-only` with `stripes-testing`, STCLI-92
 
 
 ## [1.3.0](https://github.com/folio-org/stripes-cli/tree/v1.3.0) (2018-08-07)

--- a/lib/test/nightmare-service.js
+++ b/lib/test/nightmare-service.js
@@ -94,7 +94,7 @@ module.exports = class NightmareService {
 
   runNightmareTests() {
     const mocha = path.join(__dirname, '../../node_modules/.bin/mocha');
-    const uiTestModule = require.resolve('@folio/ui-testing/test-module.js');
+    const uiTestModule = require.resolve('@folio/stripes-testing/test-module.js');
     logger.log('test-module path', uiTestModule);
     return this.runProcess(mocha, [uiTestModule].concat(this.testArgs));
   }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@folio/stripes-core": "^2.10.0",
-    "@folio/ui-testing": "folio-org/ui-testing#framework-only",
+    "@folio/stripes-testing": "^1.0.0",
     "babel-plugin-istanbul": "^4.1.6",
     "configstore": "^3.1.1",
     "debug": "^3.1.0",

--- a/test/test/nightmare-service.spec.js
+++ b/test/test/nightmare-service.spec.js
@@ -130,7 +130,7 @@ describe('The nightmare-service', function () {
     it('passes test-module to mocha', function () {
       this.sut.runNightmareTests();
       const testArgs = this.sut.runProcess.args[0][1];
-      expect(testArgs[0]).to.include('ui-testing/test-module.js');
+      expect(testArgs[0]).to.include('stripes-testing/test-module.js');
     });
 
     it('passes test args to mocha', function () {


### PR DESCRIPTION
This replaces the CLI's use of ui-testing (framework-only branch) with stripes-testing.