### PR TITLE
STCLI-100 include platforms in --run logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * STCLI-88 resolved. Resolved an issue where command test nightmare would not return process error when failing
 * Enable shell when spawning child process on Windows, fixes STCLI-89
 * Replace `ui-testing#framework-only` with `stripes-testing`, STCLI-92
+* Include platforms in logic that generates --run option for stripes-testing, STCLI-100
 
 
 ## [1.3.0](https://github.com/folio-org/stripes-cli/tree/v1.3.0) (2018-08-07)

--- a/lib/environment/inventory.js
+++ b/lib/environment/inventory.js
@@ -40,6 +40,7 @@ const platforms = [
   'stripes-sample-platform',
   'folio-testing-platform',
   'platform-core',
+  'platform-complete',
 ];
 
 // Available for cloning
@@ -48,6 +49,7 @@ const otherModules = [
   'ui-plugin-example',
   'ui-testing',
   'stripes-cli',
+  'stripes-testing',
 ];
 
 // Modules not present in a stripes.config, but do need to be included when

--- a/lib/test/nightmare-service.js
+++ b/lib/test/nightmare-service.js
@@ -1,6 +1,6 @@
 const runProcess = require('../run-process');
 const path = require('path');
-const { uiModules } = require('../environment/inventory');
+const { uiModules, platforms } = require('../environment/inventory');
 const logger = require('../cli/logger')('nightmare');
 
 const workingDirectoryToken = 'WD'; // instructs ui-testing to run tests against the working directory
@@ -36,7 +36,7 @@ module.exports = class NightmareService {
   */
   _getRunValue(options) {
     const applyWorkingDirectoryToken = (runSegment) => {
-      if (runSegment.includes(':') || runSegment.startsWith(workingDirectoryToken) || uiModules.includes(`ui-${runSegment}`)) {
+      if (runSegment.includes(':') || runSegment.startsWith(workingDirectoryToken) || uiModules.includes(`ui-${runSegment}`) || platforms.includes(runSegment)) {
         return runSegment;
       }
       return `${workingDirectoryToken}:${runSegment}`;


### PR DESCRIPTION
This includes platforms in the logic that generates the --run option for ui-testing's test-module.js.  Previously invoking a child platform's tests (such as platform-core's tests inside of platform-complete) was not possible because the CLI would handle them like local tests and apply the current working directory.  Now a platform's test script can be invoke the same way an app is handled via --run.