### PR TITLE
Pin karma-webpack to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "karma-junit-reporter": "^1.2.0",
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
-    "karma-webpack": "^3.0.2",
+    "karma-webpack": "3.0.0",
     "kopy": "^8.2.3",
     "lodash": "^4.17.5",
     "mocha": "^5.2.0",


### PR DESCRIPTION
Looks like this change: https://github.com/webpack-contrib/karma-webpack/pull/336 broke something in the way our test index gets defined. Karma then wouldn't find any tests to run.

This should get us back to a stable state.