### PR TITLE
Allow serve for settings modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Enable shell when spawning child process on Windows, fixes STCLI-89
 * Replace `ui-testing#framework-only` with `stripes-testing`, STCLI-92
 * Include platforms in logic that generates --run option for stripes-testing, STCLI-100
+* Don't throw warning when serving `settings` modules
 
 
 ## [1.3.0](https://github.com/folio-org/stripes-cli/tree/v1.3.0) (2018-08-07)

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -21,7 +21,7 @@ function serveCommand(argv, context) {
     return;
   }
 
-  if (context.type !== 'app' && context.type !== 'platform' && context.type !== 'settings') {
+  if (!(context.isUiModule || context.isStripesModule)) {
     console.warn('Please check that you are in the correct directory!\n"serve" should be run from an app or platform context.\n');
   }
 

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -21,7 +21,7 @@ function serveCommand(argv, context) {
     return;
   }
 
-  if (context.type !== 'app' && context.type !== 'platform') {
+  if (context.type !== 'app' && context.type !== 'platform' && context.type !== 'settings') {
     console.warn('Please check that you are in the correct directory!\n"serve" should be run from an app or platform context.\n');
   }
 


### PR DESCRIPTION
Discovered when trying to `stripes serve` the `ui-organization` module, which only contains settings. `stripes serve` worked, it just logged out a warning.