### PR TITLE
Upgrade webpack-bundle-analyzer

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "supports-color": "^4.5.0",
     "update-notifier": "^2.3.0",
     "webpack": "^4.10.2",
-    "webpack-bundle-analyzer": "^2.9.1",
+    "webpack-bundle-analyzer": "^3.0.1",
     "yargs": "^10.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Resolves
```
warning webpack-bundle-analyzer > bfj-node4@5.3.1: Switch to the `bfj` package for fixes and new
features!
```