### PR TITLE
STCLI-104 isPlatform fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.5.0] (IN PROGRESS)
 
 * On pull, highlight updated repositories
+* Correct isPlatform logic, fixes STCLI-104
 
 ## [1.4.0](https://github.com/folio-org/stripes-cli/tree/v1.4.0) (2018-09-10)
 * Switched from `karma-coverage` to `karma-coverage-istanbul-reporter`

--- a/lib/cli/context.js
+++ b/lib/cli/context.js
@@ -24,10 +24,6 @@ function isStripesModule(type) {
   return ['components'].some(val => val === type);
 }
 
-function isPlatform(type) {
-  return ['platform'].some(val => val === type);
-}
-
 function getContext(dir) {
   const workingDir = path.resolve(dir || '');
 
@@ -71,7 +67,6 @@ function getContext(dir) {
     ctx.moduleName = cwdPackageJson.name;
     ctx.isStripesModule = isStripesModule(ctx.type);
     ctx.isUiModule = isUiModule(ctx.type);
-    ctx.isPlatform = isPlatform(ctx.type);
     return ctx;
   }
 
@@ -85,6 +80,7 @@ function getContext(dir) {
   if (cwdPackageJson.dependencies &&
     Object.getOwnPropertyNames(cwdPackageJson.dependencies).find(key => key.startsWith('@folio/'))) {
     ctx.type = 'platform';
+    ctx.isPlatform = true;
     ctx.moduleName = cwdPackageJson.name;
     return ctx;
   }

--- a/test/cli/context.spec.js
+++ b/test/cli/context.spec.js
@@ -1,5 +1,6 @@
 const expect = require('chai').expect;
 const context = require('../../lib/cli/context');
+const path = require('path');
 
 const createModule = (type) => ({
   name: 'moduleName',
@@ -8,12 +9,12 @@ const createModule = (type) => ({
   }
 });
 
-describe('context', function () {
+describe('The CLI\'s getContext', function () {
   beforeEach(function () {
     this.sut = context.getContext;
   });
 
-  describe('stripes', function () {
+  describe('parses stripes.type from package.json', function () {
     it('is ui module with type "app"', function () {
       this.sandbox.stub(context, 'require').returns(createModule('app'));
 
@@ -23,6 +24,7 @@ describe('context', function () {
         type: 'app',
         isStripesModule: false,
         isUiModule: true,
+        isPlatform: false,
       });
     });
 
@@ -35,6 +37,7 @@ describe('context', function () {
         type: 'settings',
         isStripesModule: false,
         isUiModule: true,
+        isPlatform: false,
       });
     });
 
@@ -47,7 +50,88 @@ describe('context', function () {
         type: 'components',
         isStripesModule: true,
         isUiModule: false,
+        isPlatform: false,
       });
     });
   });
+
+  it('identifies platforms', function () {
+    this.sandbox.stub(context, 'require').returns({
+      name: '@folio/platform-core',
+      dependencies: { '@folio/stripes-core': '1.2.3' }
+    });
+    const result = this.sut('someDir');
+
+    expect(result).to.include({
+      type: 'platform',
+      isStripesModule: false,
+      isUiModule: false,
+      isPlatform: true,
+    });
+  });
+
+  it('identifies workspaces', function () {
+    this.sandbox.stub(context, 'require').returns({
+      workspaces: [],
+    });
+    const result = this.sut('someDir');
+
+    expect(result).to.include({
+      type: 'workspace',
+      isStripesModule: false,
+      isUiModule: false,
+      isPlatform: false,
+    });
+  });
+
+  it('identifies itself', function () {
+    this.sandbox.stub(context, 'require').returns({
+      name: '@folio/stripes-cli',
+    });
+    const result = this.sut(path.resolve(__dirname, '../..'));
+
+    expect(result).to.include({
+      type: 'cli',
+      isStripesModule: false,
+      isUiModule: false,
+      isPlatform: false,
+    });
+  });
+
+  it('handles no package.json', function () {
+    this.sandbox.stub(context, 'require').throws();
+    const result = this.sut('someDir');
+
+    expect(result).to.include({
+      type: 'empty',
+      isStripesModule: false,
+      isUiModule: false,
+      isPlatform: false,
+    });
+  });
+
+  it('identifies when a local stripes-core is available', function () {
+    this.sandbox.stub(context, 'require').returns({
+      name: '@folio/platform-core',
+      dependencies: { '@folio/stripes-core': '1.2.3' }
+    });
+    const result = this.sut('someDir');
+
+    expect(result).to.include({
+      isLocalCoreAvailable: true,
+    });
+  });
+
+  it('identifies when a local stripes-core is not available', function () {
+    this.sandbox.stub(context, 'require').returns({
+      name: '@folio/platform-core',
+      dependencies: { '@folio/not-stripes-core': '1.2.3' }
+    });
+    const result = this.sut('someDir');
+
+    expect(result).to.include({
+      isLocalCoreAvailable: false,
+    });
+  });
+
 });

--- a/test/cli/context.spec.js
+++ b/test/cli/context.spec.js
@@ -133,5 +133,4 @@ describe('The CLI\'s getContext', function () {
       isLocalCoreAvailable: false,
     });
   });
-
 });


### PR DESCRIPTION
Recently added `isPlatform` logic was dependent on the `stripes.type` property used by ui modules.  However, platforms don't currently define `stripes` property their package.json.  (Perhaps they should?)

This fix sets isPlatform at the same time context.type is assigned "platform", allowing existing checks for `context.type === 'platform'` to migrate to `context.isPlatform`.