### PR TITLE
start new apps at v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * On pull, highlight updated repositories
 * Correct isPlatform logic, fixes STCLI-104
+* Start new apps at v1.0.0. Fixes STCLI-105
 
 ## [1.4.0](https://github.com/folio-org/stripes-cli/tree/v1.4.0) (2018-09-10)
 * Switched from `karma-coverage` to `karma-coverage-istanbul-reporter`

--- a/resources/ui-app/package.json
+++ b/resources/ui-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "<%= packageName %>",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "<%= appDescription %>",
   "main": "src/index.js",
   "repository": "",


### PR DESCRIPTION
Semantic versioning treats caret deps on versions with leading 0s like
tilde deps, i.e. only the patch version can change. Starting all apps
and libraries at v1.0.0 instead of v0.1.0 avoids the confusion and pain
that otherwise results from bumping the minor version of a v0.x.y
module and finding that it isn't being pulled in as anticipated.

Fixes [STCLI-105](https://issues.folio.org/browse/STCLI-105)