### PR TITLE
STCLI-106 Ensure module is enabled before assigning permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Correct isPlatform logic, fixes STCLI-104
 * Start new apps at v1.0.0. Fixes STCLI-105
 * Upgrade `debug` dependency, STRIPES-553
+* Enable module for tenant via `perm create` command, fixes STCLI-106
 
 
 ## [1.4.0](https://github.com/folio-org/stripes-cli/tree/v1.4.0) (2018-09-10)

--- a/lib/commands/perm/create.js
+++ b/lib/commands/perm/create.js
@@ -6,6 +6,7 @@ const Okapi = importLazy('../../okapi');
 const PermissionService = importLazy('../../okapi/permission-service');
 const { applyOptions, okapiOptions } = importLazy('../common-options');
 const addModCommand = importLazy('../mod/add');
+const enableModCommand = importLazy('../mod/enable');
 const updateModCommand = importLazy('../mod/update');
 const assignPermCommand = importLazy('../perm/assign');
 
@@ -51,8 +52,10 @@ function createPermCommand(argv, context) {
     })
     .then(() => {
       // Assign the new permission to a user
+      // and make sure it is enabled for the tenant first
       if (argv.assign) {
-        return assignPermCommand.handler(argv);
+        return enableModCommand.handler(argv)
+          .then(() => assignPermCommand.handler(argv));
       }
       return Promise.resolve();
     });

--- a/lib/okapi/module-service.js
+++ b/lib/okapi/module-service.js
@@ -121,7 +121,7 @@ module.exports = class ModuleService {
           // TODO: Establish a more elegant way of extracting the tenant id(s) and handle case for multiple
           const split = error.message.split(' ');
           tenant = split[split.length - 1];
-          return this.disassociateModuleWithTenant(moduleDescriptor, tenant)
+          return this.disableModuleForTenant(moduleDescriptor.id, tenant)
             .then(() => this.removeModuleDescriptor(moduleDescriptor));
         } else {
           throw error;
@@ -130,7 +130,7 @@ module.exports = class ModuleService {
       .then(() => this.addModuleDescriptor(moduleDescriptor))
       .then(() => {
         if (tenant) {
-          return this.associateModuleWithTenant(moduleDescriptor, tenant);
+          return this.enableModuleForTenant(moduleDescriptor.id, tenant);
         }
         return Promise.resolve({ id: moduleDescriptor.id, success: true });
       });

--- a/lib/okapi/module-service.js
+++ b/lib/okapi/module-service.js
@@ -51,7 +51,7 @@ module.exports = class ModuleService {
   addModuleDescriptor(moduleDescriptor) {
     return this.okapi.proxy.addModuleDescriptor(moduleDescriptor)
       .then(() => ({ id: moduleDescriptor.id, success: true }))
-      .catch(resolveIfOkapiSays('exists already', { id: moduleDescriptor.id, alreadyExists: true }));
+      .catch(resolveIfOkapiSays('already exists', { id: moduleDescriptor.id, alreadyExists: true }));
   }
 
   removeModuleDescriptor(moduleDescriptor) {

--- a/lib/okapi/okapi-repository.js
+++ b/lib/okapi/okapi-repository.js
@@ -16,8 +16,8 @@ function addModuleDescriptor(moduleDescriptor) {
   return okapiClient.post('/_/proxy/modules', moduleDescriptor, noTenantNoToken);
 }
 
-function removeModuleDescriptor(moduleDescriptor) {
-  return okapiClient.delete(`/_/proxy/modules/${moduleDescriptor}`, noTenantNoToken);
+function removeModuleDescriptor(moduleDescriptorId) {
+  return okapiClient.delete(`/_/proxy/modules/${moduleDescriptorId}`, noTenantNoToken);
 }
 
 function enableModuleForTenant(moduleDescriptorId, tenant) {


### PR DESCRIPTION
Stripes CLI provides an easy way to create new permissions for ui-modules with `stripes perm create`.  The new permission can be optionally assigned to a user with `--assign` at the same time.

However, if the module is not already enabled for a tenant, this optional step fails.  By calling into existing `mod enable` logic, we can ensure the module is enabled for the tenant before assigning the newly created permission to a user.

Another issue was uncovered in that outdated method names were still referenced from within `updateModuleDescriptor()` to enable/disable modules.

Fixes STCLI-106