### PR TITLE
Add core stripes module type

### DIFF
--- a/lib/cli/context.js
+++ b/lib/cli/context.js
@@ -22,7 +22,7 @@ function isUiModule(type) {
 }
 
 function isStripesModule(type) {
-  return ['components'].some(val => val === type);
+  return ['core', 'components'].some(val => val === type);
 }
 
 function getContext(dir) {


### PR DESCRIPTION
## Purpose

Adds `core` to the `isStripesModule` check so that the CLI can be used to run tests in `stripes-core`.