### PR TITLE
Expand isStripesModule logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Start new apps at v1.0.0. Fixes STCLI-105
 * Upgrade `debug` dependency, STRIPES-553
 * Enable module for tenant via `perm create` command, fixes STCLI-106
+* Enable serve/test of stripes-* modules based on inventory
 
 
 ## [1.4.0](https://github.com/folio-org/stripes-cli/tree/v1.4.0) (2018-09-10)

--- a/lib/cli/context.js
+++ b/lib/cli/context.js
@@ -5,6 +5,7 @@ const logger = require('./logger')();
 // TODO: Yarn 1.5.1 changed global install directory on Windows, 'global-dirs' does not yet reflect this
 // https://github.com/yarnpkg/yarn/pull/5336
 const globalDirs = require('./global-dirs');
+const { stripesModules, toFolioName } = require('../environment/inventory');
 
 
 const cliRoot = path.join(__dirname, '..', '..');
@@ -21,8 +22,8 @@ function isUiModule(type) {
   return ['app', 'settings'].some(val => val === type);
 }
 
-function isStripesModule(type) {
-  return ['components'].some(val => val === type);
+function isStripesModule(name) {
+  return stripesModules.some(val => toFolioName(val) === name);
 }
 
 function getContext(dir) {
@@ -66,7 +67,7 @@ function getContext(dir) {
   if (cwdPackageJson.stripes) {
     ctx.type = cwdPackageJson.stripes.type;
     ctx.moduleName = cwdPackageJson.name;
-    ctx.isStripesModule = isStripesModule(ctx.type);
+    ctx.isStripesModule = isStripesModule(cwdPackageJson.name);
     ctx.isUiModule = isUiModule(ctx.type);
     return ctx;
   }

--- a/test/cli/context.spec.js
+++ b/test/cli/context.spec.js
@@ -3,7 +3,7 @@ const path = require('path');
 const context = require('../../lib/cli/context');
 
 const createModule = (type) => ({
-  name: 'moduleName',
+  name: type === 'components' ? '@folio/stripes-components' : '@folio/ui-app',
   stripes: {
     type,
   }
@@ -79,6 +79,20 @@ describe('The CLI\'s getContext', function () {
     expect(result).to.include({
       type: 'workspace',
       isStripesModule: false,
+      isUiModule: false,
+      isPlatform: false,
+    });
+  });
+
+  it('identifies stripes modules', function () {
+    this.sandbox.stub(context, 'require').returns({
+      name: '@folio/stripes-core',
+      stripes: {},
+    });
+    const result = this.sut('someDir');
+
+    expect(result).to.include({
+      isStripesModule: true,
       isUiModule: false,
       isPlatform: false,
     });


### PR DESCRIPTION
This enables the CLI to serve/test from within more stripes-* module directories.  Basing `isStripesModule` on the CLI's `stripesModules` inventory helps to ensure consistency.

Next steps: Review the various context checks within the CLI and consider relaxing or revoking them.  Not all may be necessary and and in fact a few have proven to interfere as observed here and in STLI-78.