### PR TITLE
Release v.1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for stripes-cli
 
-## [1.5.0] (IN PROGRESS)
+## [1.5.0](https://github.com/folio-org/stripes-cli/tree/v1.5.0) (2018-09-24)
 
 * On pull, highlight updated repositories
 * Correct isPlatform logic, fixes STCLI-104

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-cli",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Stripes Command Line Interface",
   "repository": "https://github.com/folio-org/stripes-cli",
   "publishConfig": {

--- a/resources/platform/package.json
+++ b/resources/platform/package.json
@@ -7,7 +7,7 @@
     "build": "stripes build stripes.config.js"
   },
   "devDependencies": {
-    "@folio/stripes-cli": "^1.4.0"
+    "@folio/stripes-cli": "^1.5.0"
   },
   "dependencies": {
   }

--- a/resources/ui-app/package.json
+++ b/resources/ui-app/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^3.2.1",
-    "@folio/stripes-cli": "^1.4.0",
+    "@folio/stripes-cli": "^1.5.0",
     "babel-eslint": "^9.0.0",
     "eslint": "^5.6.0"
   },


### PR DESCRIPTION
Unblocks https://github.com/folio-org/stripes-core/pull/426

After merge, will create tag and publish to https://repository.folio.org/repository/npm-folio/.