### PR TITLE
Remove HMR plugin during Karma tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for stripes-cli
 
+## 1.6.0 (IN PROGRESS)
+
+* Remove HMR plugin during Karma tests
+
+
 ## [1.5.0](https://github.com/folio-org/stripes-cli/tree/v1.5.0) (2018-09-24)
 
 * On pull, highlight updated repositories

--- a/lib/commands/test/karma.js
+++ b/lib/commands/test/karma.js
@@ -33,6 +33,11 @@ function karmaCommand(argv, context) {
   };
   const webpackConfig = stripes.getStripesWebpackConfig(platform.getStripesConfig(), webpackConfigOptions);
 
+  // remove hmr plugin during testing
+  webpackConfig.webpack.plugins = webpackConfig.webpack.plugins.filter(plugin => {
+    return plugin.constructor.name !== 'HotModuleReplacementPlugin';
+  });
+
   const karmaService = new KarmaService(context.cwd);
   karmaService.runKarmaTests(webpackConfig, argv.karma);
 }

--- a/lib/commands/test/karma.js
+++ b/lib/commands/test/karma.js
@@ -33,11 +33,6 @@ function karmaCommand(argv, context) {
   };
   const webpackConfig = stripes.getStripesWebpackConfig(platform.getStripesConfig(), webpackConfigOptions);
 
-  // remove hmr plugin during testing
-  webpackConfig.webpack.plugins = webpackConfig.webpack.plugins.filter(plugin => {
-    return plugin.constructor.name !== 'HotModuleReplacementPlugin';
-  });
-
   const karmaService = new KarmaService(context.cwd);
   karmaService.runKarmaTests(webpackConfig, argv.karma);
 }

--- a/lib/test/webpack-config.js
+++ b/lib/test/webpack-config.js
@@ -34,6 +34,11 @@ module.exports = function getStripesWebpackConfig(stripeCore, stripesConfig, opt
     );
   }
 
+  // Remove HMR plugin during testing
+  config.plugins = config.plugins.filter(plugin => {
+    return plugin.constructor.name !== 'HotModuleReplacementPlugin';
+  });
+
   config = applyWebpackOverrides(options.webpackOverrides, config);
   return config;
 };


### PR DESCRIPTION
Discovered during long `ui-eholdings` test runs that were causing browser crashes.

Thanks @wwilsman for the fix.