### PR TITLE
STCLI-67: Update app module template with new translation directory

### DIFF
--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -30,7 +30,13 @@ function createApp(appName, appDescription) {
   const templateDir = path.join(__dirname, '..', 'resources/ui-app');
   const appDir = path.resolve(data.appDir);
 
-  return copy(templateDir, appDir, { data, clean: false }).then(() => {
+  return copy(templateDir, appDir, {
+    data,
+    move: {
+      'translations/en.json': `translations/${data.uiAppName}/en.json`,
+    },
+    clean: false,
+  }).then(() => {
     console.log('App created successfully');
     return data;
   }).catch((err) => {

--- a/resources/ui-app/CHANGELOG.md
+++ b/resources/ui-app/CHANGELOG.md
@@ -3,3 +3,5 @@
 ## 0.1.0 (IN PROGRESS)
 
 * New app created with stripes-cli
+
+* Update app module template with new translation directory, [STCLI-67](https://github.com/folio-org/stripes-cli/pull/133)


### PR DESCRIPTION
## Purpose
Concerning [STCLI-67](https://issues.folio.org/browse/STCLI-67), the template for generating app-module should be updated due to lokalize.co restrictions, so that, the language files should be moved to new path `translations/<ui-app-name>/en.json`. 

For example, in case of ui-users the language files (`translations/en.json`) should move to `translations/ui-users/en.json`.

Therefore, the stripes-translations-plugin must look for translations in both translations/ and translations/moduleName.


## Approach
- using [copy](translations/<ui-app-name>/en.json.) add option 'move', that allows to rename files.

![screen shot 2018-11-01 at 17 24 03](https://user-images.githubusercontent.com/43647240/47861271-15f97580-ddfb-11e8-8714-892bd1b89b2e.png)
