### PR TITLE
STCLI-111 stripes-core deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Rename `mod view` to `mod list` and add support for listing all module ids, STCLI-79
 * New `mod view` implementation to view module descriptors given ids, STCLI-79
+* Update app module template with new translation directory, STCLI-67
 * Augment core API with dependencies used for generating descriptors, fixes STCLI-111
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Rename `mod view` to `mod list` and add support for listing all module ids, STCLI-79
 * New `mod view` implementation to view module descriptors given ids, STCLI-79
+* Augment core API with dependencies used for generating descriptors, fixes STCLI-111
 
 
 ## [1.6.0](https://github.com/folio-org/stripes-cli/tree/v1.6.0) (2018-10-19)

--- a/lib/cli/stripes-core.js
+++ b/lib/cli/stripes-core.js
@@ -17,6 +17,8 @@ module.exports = class StripesCore {
   get api() {
     if (!this.nodeApi) {
       this.nodeApi = this.getCoreModule('webpack/stripes-node-api');
+      // Augment the API with these dependencies used to create module descriptors
+      // These assignments can be removed once stripes-core includes them within the API
       this.nodeApi.StripesModuleParser = this.getCoreModule('webpack/stripes-module-parser').StripesModuleParser;
       this.nodeApi.StripesBuildError = this.getCoreModule('webpack/stripes-build-error');
     }

--- a/lib/cli/stripes-core.js
+++ b/lib/cli/stripes-core.js
@@ -17,6 +17,8 @@ module.exports = class StripesCore {
   get api() {
     if (!this.nodeApi) {
       this.nodeApi = this.getCoreModule('webpack/stripes-node-api');
+      this.nodeApi.StripesModuleParser = this.getCoreModule('webpack/stripes-module-parser').StripesModuleParser;
+      this.nodeApi.StripesBuildError = this.getCoreModule('webpack/stripes-build-error');
     }
     return this.nodeApi;
   }

--- a/lib/okapi/module-service.js
+++ b/lib/okapi/module-service.js
@@ -13,6 +13,7 @@ module.exports = class ModuleService {
     this.okapi = okapiRepository;
   }
 
+  // TODO: Consider moving this along with cli/generate-module-descriptor into a dedicated descriptor-service
   static getModuleDescriptorsFromContext(context, configFile, isStrict) {
     const packageJsons = [];
 

--- a/lib/okapi/module-service.js
+++ b/lib/okapi/module-service.js
@@ -1,10 +1,7 @@
 const path = require('path');
 const { uniq } = require('lodash');
 
-// TODO: Export via stripes-core Node API
-const parser = require('@folio/stripes-core/webpack/stripes-module-parser');
-const StripesBuildError = require('@folio/stripes-core/webpack/stripes-build-error');
-
+const StripesCore = require('../cli/stripes-core');
 const { resolveIfOkapiSays } = require('../okapi/okapi-utils');
 const OkapiError = require('./okapi-error');
 const generateModuleDescriptor = require('../cli/generate-module-descriptor');
@@ -22,6 +19,8 @@ module.exports = class ModuleService {
     if (context.type === 'platform') {
       // Initialize a platform to take aliases, if any, into account
       const platform = new StripesPlatform(configFile, context);
+      const stripesCore = new StripesCore(context, platform.aliases);
+
       const stripesConfig = platform.getStripesConfig();
 
       const moduleNames = Object.getOwnPropertyNames(stripesConfig.modules);
@@ -30,10 +29,10 @@ module.exports = class ModuleService {
       uniq(moduleNames.concat(extraModuleNames)).forEach(moduleName => {
         // The StripesModuleParser's constructor takes care of locating a module's package.json
         try {
-          const moduleParser = new parser.StripesModuleParser(moduleName, {}, context.cwd, platform.aliases);
+          const moduleParser = new stripesCore.api.StripesModuleParser(moduleName, {}, context.cwd, platform.aliases);
           packageJsons.push(moduleParser.packageJson);
         } catch (err) {
-          if (err instanceof StripesBuildError && extraModuleNames.includes(moduleName)) {
+          if (err instanceof stripesCore.api.StripesBuildError && extraModuleNames.includes(moduleName)) {
             // Quietly ignore if the platform doesn't actually have these extra modules
           } else {
             throw (err);

--- a/resources/ui-app/CHANGELOG.md
+++ b/resources/ui-app/CHANGELOG.md
@@ -3,5 +3,3 @@
 ## 0.1.0 (IN PROGRESS)
 
 * New app created with stripes-cli
-
-* Update app module template with new translation directory, [STCLI-67](https://github.com/folio-org/stripes-cli/pull/133)


### PR DESCRIPTION
This imports the stripes-core dependencies responsible for locating stripes-* modules via the CLI's stripes-core API wrapper.  Doing so ensures the version of stripes-core used for building a platform is the same version used for generating module descriptors for the platform.  Fixes STCLI-111.