### PR TITLE
STCLI-15 setup backend for platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 * New `mod view` implementation to view module descriptors given ids, STCLI-79
 * Update app module template with new translation directory, STCLI-67
 * Augment core API with dependencies used for generating descriptors, fixes STCLI-111
+* Extend Okapi interactions to facilitate setup of back-end platform dependencies, STCLI-15
+  * Pull module descriptors from remote Okapi registry with `mod pull`
+  * `mod remove` now supports multiple descriptor ids
+  * Enable/disable and optionally deploy modules via `mod install`
+  * Deploy, enable, and upgrade modules for a platform via `platform backend`
 
 
 ## [1.6.0](https://github.com/folio-org/stripes-cli/tree/v1.6.0) (2018-10-19)

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -832,8 +832,8 @@ stripes mod install
 
 Option | Description | Type | Notes
 ---|---|---|---
-`--okapi` | Specify an Okapi URL | string |
-`--tenant` | Specify a tenant ID | string |
+`--okapi` | Specify an Okapi URL | string | (*)
+`--tenant` | Specify a tenant ID | string | (*)
 `--simulate` | Perform a dry run | boolean |
 `--ids` | Module descriptor ids  | array | supports stdin
 

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -655,7 +655,7 @@ stripes mod add
 
 ### `mod remove` command
 
-Remove an app module descriptor from Okapi
+Remove a module descriptor from Okapi
 
 Usage:
 ```
@@ -664,14 +664,23 @@ stripes mod remove
 
 Option | Description | Type | Notes
 ---|---|---|---
-`--okapi` | Specify an Okapi URL | string |
-`--tenant` | Specify a tenant ID | string |
-
+`--okapi` | Specify an Okapi URL | string | 
+`--tenant` | Specify a tenant ID | string | 
+`--ids` | Module descriptor ids | array | 
 
 Examples:
 
+Remove ui-module located in current directory:
 ```
 stripes mod remove
+```
+Remove module ids "one" and "two" from Okapi:
+```
+stripes mod remove --ids one two
+```
+Remove module ids "one" and "two" from Okapi with stdin:
+```
+echo one two | stripes mod remove
 ```
 
 ### `mod enable` command

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -9,7 +9,7 @@ This following command documentation is largely generated from the CLI's own bui
     * [`app bigtest` command](#app-bigtest-command)
 * [`serve` command](#serve-command)
 * [`build` command](#build-command)
-* [`test` command (work in progress)](#test-command-work-in-progress)
+* [`test` command](#test-command)
     * [`test nightmare` command](#test-nightmare-command)
     * [`test karma` command](#test-karma-command)
 * [`status` command](#status-command)
@@ -32,7 +32,7 @@ This following command documentation is largely generated from the CLI's own bui
     * [`mod update` command](#mod-update-command)
     * [`mod descriptor` command](#mod-descriptor-command)
     * [`mod list` command](#mod-list-command)
-    * [`mod install` command (work in progress)](#mod-install-command-work-in-progress)
+    * [`mod install` command](#mod-install-command)
     * [`mod view` command](#mod-view-command)
     * [`mod pull` command](#mod-pull-command)
 * [`perm` command](#perm-command)
@@ -256,7 +256,7 @@ stripes build --output=dir
 ```
 
 
-## `test` command (work in progress)
+## `test` command
 
 Run the current app module's tests
 
@@ -521,21 +521,45 @@ stripes platform install
 
 ### `platform backend` command (work in progress)
 
-Initialize Okapi backend for a platform (work in progress)
+Initialize Okapi backend for a platform
 
 Usage:
 ```
 stripes platform backend [configFile]
 ```
 
+Positional | Description | Type | Notes
+---|---|---|---
+`configFile` | File containing a Stripes tenant configuration | string | 
+
 Option | Description | Type | Notes
 ---|---|---|---
 `--okapi` | Specify an Okapi URL | string | (*)
 `--tenant` | Specify a tenant ID | string | (*)
-`--simulate` | Perform a dry run | boolean |
-`--remote` | Update module descriptors via remote before install | string |
-`--include` | Additional backend module ids to include with install | array |
+`--simulate` | Simulate install only (does not deploy) | boolean | default: false
+`--preRelease` | Include pre-release modules | boolean | default: true
+`--remote` | Pull module descriptors from remote registry before install | string | 
+`--include` | Additional module ids to include with install | array | 
+`--detail` | Display detailed output | boolean | default: false
 
+Examples:
+
+Deploy, enable, and/or upgrade modules to support the current platform:
+```
+stripes platform backend stripes.config.js
+```
+View modules that need to enabled/upgraded for the current platform:
+```
+stripes platform backend stripes.config.js --simulate --detail
+```
+Pull module descriptors from remote Okapi prior to install:
+```
+stripes platform backend stripes.config.js --remote http://folio-registry.aws.indexdata.com
+```
+Include modules "one" and "two" not specified in tenant config:
+```
+stripes platform backend stripes.config.js --include one two
+```
 
 ## `alias` command
 Maintain global aliases that apply to all platforms and apps
@@ -840,9 +864,9 @@ List available module ids in Okapi (overriding any tenant set via config):
 stripes mod list --no-tenant
 ```
 
-### `mod install` command (work in progress)
+### `mod install` command
 
-Enable, disable, or upgrade one or more modules for a tenant in Okapi (work in progress)
+Enable, disable, and optionally deploy one or more modules for a tenant in Okapi
 
 Usage:
 ```
@@ -853,14 +877,21 @@ Option | Description | Type | Notes
 ---|---|---|---
 `--okapi` | Specify an Okapi URL | string | (*)
 `--tenant` | Specify a tenant ID | string | (*)
-`--simulate` | Perform a dry run | boolean |
+`--simulate` | Simulate operation | boolean | default: false
+`--action` | Action to perform on modules | string | choices: "enable", "disable"
+`--deploy` | Deploy modules | boolean | default: false
+`--preRelease` | Include pre-release modules | boolean | default: true
 `--ids` | Module descriptor ids  | array | supports stdin
 
 Examples:
 
-Install module ids "one" and "two":
+Install and deploy module ids "one" and "two":
 ```
-stripes mod install --ids one two --tenant diku
+stripes mod install --ids one two --tenant diku --deploy
+```
+Disable module ids "one" and "two":
+```
+stripes mod install --ids one two --tenant diku --action disable
 ```
 Install module ids "one" and "two" using stdin:
 ```

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -18,6 +18,7 @@ This following command documentation is largely generated from the CLI's own bui
     * [`platform pull` command](#platform-pull-command)
     * [`platform clean` command](#platform-clean-command)
     * [`platform install` command](#platform-install-command)
+    * [`platform backend` command (work in progress)](#platform-backend-command-work-in-progress)
 * [`alias` command](#alias-command)
 * [`okapi` command](#okapi-command)
     * [`okapi login` command](#okapi-login-command)
@@ -518,6 +519,24 @@ Usage:
 stripes platform install
 ```
 
+### `platform backend` command (work in progress)
+
+Initialize Okapi backend for a platform (work in progress)
+
+Usage:
+```
+stripes platform backend [configFile]
+```
+
+Option | Description | Type | Notes
+---|---|---|---
+`--okapi` | Specify an Okapi URL | string | (*)
+`--tenant` | Specify a tenant ID | string | (*)
+`--simulate` | Perform a dry run | boolean |
+`--remote` | Update module descriptors via remote before install | string |
+`--include` | Additional backend module ids to include with install | array |
+
+
 ## `alias` command
 Maintain global aliases that apply to all platforms and apps
 
@@ -768,7 +787,7 @@ Generate module descriptors for an app or platform.
 
 Usage:
 ```
-stripes mod descriptor
+stripes mod descriptor [configFile]
 ```
 
 Option | Description | Type | Notes

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -33,6 +33,7 @@ This following command documentation is largely generated from the CLI's own bui
     * [`mod list` command](#mod-list-command)
     * [`mod install` command (work in progress)](#mod-install-command-work-in-progress)
     * [`mod view` command](#mod-view-command)
+    * [`mod pull` command](#mod-pull-command)
 * [`perm` command](#perm-command)
     * [`perm create` command](#perm-create-command)
     * [`perm assign` command](#perm-assign-command)
@@ -626,6 +627,7 @@ Sub-commands:
 * `stripes mod enable`
 * `stripes mod install`
 * `stripes mod list`
+* `stripes mod pull`
 * `stripes mod remove`
 * `stripes mod update`
 * `stripes mod view`
@@ -870,6 +872,28 @@ stripes mod view --ids one two
 View module descriptors for ids "one" and "two" with stdin:
 ```
 echo one two | stripes mod view
+```
+
+### `mod pull` command
+
+Pull module descriptors from a remote okapi
+
+Usage:
+```
+stripes mod pull --remote http://folio-registry.aws.indexdata.com
+```
+
+Option | Description | Type | Notes
+---|---|---|---
+`--okapi` | Specify an Okapi URL | string | 
+`--tenant` | Specify a tenant ID | string | 
+`--remote` | Remote Okapi to pull from | string | (*) 
+
+Examples:
+
+Pull module descriptors from remote Okapi:
+```
+stripes mod pull --okapi http://localhost:9130 --remote http://folio-registry.aws.indexdata.com
 ```
 
 ## `perm` command

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -316,7 +316,7 @@ Option | Description | Type | Notes
 `--languages` | Languages to include in tenant build | array |
 `--run` | Name of the test script to run | string |
 `--show` | Show UI and dev tools while running tests | boolean |
-`--url` | URL of FOLIO UI to run tests against | string | 
+`--url` | URL of FOLIO UI to run tests against | string |
 `--local` | Shortcut for --url http://localhost:3000 | boolean | defaults to --host and --port
 `--uiTest` | Additional options for ui-testing framework |  |
 
@@ -643,12 +643,12 @@ stripes mod add
 
 Option | Description | Type | Notes
 ---|---|---|---
-`--okapi` | Specify an Okapi URL | string |
-`--tenant` | Specify a tenant ID | string |
+`--okapi` | Specify an Okapi URL | string | (*)
 `--strict` | Include required interface dependencies | boolean | default: false
 
 Examples:
 
+Add descriptor for ui-module in current directory:
 ```
 stripes mod add
 ```
@@ -664,9 +664,8 @@ stripes mod remove
 
 Option | Description | Type | Notes
 ---|---|---|---
-`--okapi` | Specify an Okapi URL | string | 
-`--tenant` | Specify a tenant ID | string | 
-`--ids` | Module descriptor ids | array | 
+`--okapi` | Specify an Okapi URL | string | (*)
+`--ids` | Module descriptor ids  | array | supports stdin
 
 Examples:
 
@@ -692,13 +691,11 @@ Usage:
 stripes mod enable
 ```
 
-
 Option | Description | Type | Notes
 ---|---|---|---
-`--okapi` | Specify an Okapi URL | string |
-`--tenant` | Specify a tenant ID | string |
-`--ids` | Module descriptor ids | array | supports stdin
-
+`--okapi` | Specify an Okapi URL | string | (*)
+`--tenant` | Specify a tenant ID | string | (*)
+`--ids` | Module descriptor ids  | array | supports stdin
 
 Examples:
 
@@ -715,7 +712,6 @@ Enable module ids "one" and "two" for tenant diku with stdin:
 echo one two | stripes mod enable --tenant diku
 ```
 
-
 ### `mod disable` command
 
 Disable modules for a tenant in Okapi
@@ -727,10 +723,9 @@ stripes mod disable
 
 Option | Description | Type | Notes
 ---|---|---|---
-`--okapi` | Specify an Okapi URL | string |
-`--tenant` | Specify a tenant ID | string |
-`--ids` | Module descriptor ids | array | supports stdin
-
+`--okapi` | Specify an Okapi URL | string | (*)
+`--tenant` | Specify a tenant ID | string | (*)
+`--ids` | Module descriptor ids  | array | supports stdin
 
 Examples:
 
@@ -747,7 +742,6 @@ Disable module ids "one" and "two" for tenant diku with stdin:
 echo one two | stripes mod disable --tenant diku
 ```
 
-
 ### `mod update` command
 
 Update an app module descriptor in Okapi
@@ -757,12 +751,13 @@ Usage:
 stripes mod update
 ```
 
-
 Option | Description | Type | Notes
 ---|---|---|---
-`--okapi` | Specify an Okapi URL | string |
-`--tenant` | Specify a tenant ID | string |
+`--okapi` | Specify an Okapi URL | string | (*)
 
+Examples:
+
+Update descriptor for ui-module in current directory:
 ```
 stripes mod update
 ```
@@ -776,13 +771,11 @@ Usage:
 stripes mod descriptor
 ```
 
-
 Option | Description | Type | Notes
 ---|---|---|---
 `--configFile` | File containing a Stripes tenant configuration (platform context only) | string |
 `--full` | Return full module descriptor JSON | boolean | default: false
 `--strict` | Include required interface dependencies | boolean | default: false
-
 
 Examples:
 
@@ -810,7 +803,7 @@ stripes mod list
 
 Option | Description | Type | Notes
 ---|---|---|---
-`--okapi` | Specify an Okapi URL | string |
+`--okapi` | Specify an Okapi URL | string | (*)
 `--tenant` | Specify a tenant ID | string |
 
 Examples:
@@ -841,13 +834,12 @@ Option | Description | Type | Notes
 ---|---|---|---
 `--okapi` | Specify an Okapi URL | string |
 `--tenant` | Specify a tenant ID | string |
-`--ids` | Module descriptor ids | array | supports stdin
 `--simulate` | Perform a dry run | boolean |
-
+`--ids` | Module descriptor ids  | array | supports stdin
 
 Examples:
 
-Install modules "one" and "two":
+Install module ids "one" and "two":
 ```
 stripes mod install --ids one two --tenant diku
 ```
@@ -867,10 +859,8 @@ stripes mod view
 
 Option | Description | Type | Notes
 ---|---|---|---
-`--okapi` | Specify an Okapi URL | string | 
-`--tenant` | Specify a tenant ID | string | 
-`--ids` | Module descriptor ids | array | 
-
+`--okapi` | Specify an Okapi URL | string | (*)
+`--ids` | Module descriptor ids  | array | supports stdin
 
 Examples:
 
@@ -889,14 +879,13 @@ Pull module descriptors from a remote okapi
 
 Usage:
 ```
-stripes mod pull --remote http://folio-registry.aws.indexdata.com
+stripes mod pull
 ```
 
 Option | Description | Type | Notes
 ---|---|---|---
-`--okapi` | Specify an Okapi URL | string | 
-`--tenant` | Specify a tenant ID | string | 
-`--remote` | Remote Okapi to pull from | string | (*) 
+`--okapi` | Specify an Okapi URL | string | (*)
+`--remote` | Remote Okapi to pull from | string | (*)
 
 Examples:
 

--- a/doc/generator.js
+++ b/doc/generator.js
@@ -66,7 +66,7 @@ function getOptions(group) {
     if (optionMatch && optionMatch.length) {
       const option = parseOption(optionMatch);
       if (option) {
-        const description = option.stdin ? option.description.replace('(stdin)', '') : option.description;       
+        const description = option.stdin ? option.description.replace('(stdin)', '') : option.description;
         const notes = [
           option.required ? '(*)' : '',
           option.default ? `default: ${option.default}` : '',

--- a/lib/commands/common-options.js
+++ b/lib/commands/common-options.js
@@ -45,7 +45,7 @@ module.exports.authOptions = {
   },
 };
 
-module.exports.okapiOptions = {
+const okapiOptions = {
   okapi: {
     type: 'string',
     describe: 'Specify an Okapi URL',
@@ -56,6 +56,31 @@ module.exports.okapiOptions = {
     describe: 'Specify a tenant ID',
     group: 'Okapi Options:',
   },
+};
+
+module.exports.okapiOptions = okapiOptions;
+
+module.exports.okapiOption = {
+  okapi: okapiOptions.okapi,
+};
+
+module.exports.tenantOption = {
+  tenant: okapiOptions.tenant,
+};
+
+module.exports.okapiRequired = {
+  okapi: Object.assign({}, okapiOptions.okapi, { required: true }),
+};
+
+module.exports.tenantRequired = {
+  tenant: Object.assign({}, okapiOptions.tenant, { required: true }),
+};
+
+module.exports.moduleIdsStdin = {
+  ids: {
+    describe: 'Module descriptor ids (stdin)',
+    type: 'array',
+  }
 };
 
 module.exports.stripesConfigOptions = {

--- a/lib/commands/mod/add.js
+++ b/lib/commands/mod/add.js
@@ -3,7 +3,7 @@ const importLazy = require('import-lazy')(require);
 const { mainHandler } = importLazy('../../cli/main-handler');
 const Okapi = importLazy('../../okapi');
 const ModuleService = importLazy('../../okapi/module-service');
-const { applyOptions, okapiOptions } = importLazy('../common-options');
+const { applyOptions, okapiRequired } = importLazy('../common-options');
 
 
 function addModuleDescriptorCommand(argv, context) {
@@ -38,8 +38,8 @@ module.exports = {
         type: 'boolean',
         default: false,
       })
-      .example('$0 mod add', '');
-    return applyOptions(yargs, Object.assign({}, okapiOptions));
+      .example('$0 mod add', 'Add descriptor for ui-module in current directory');
+    return applyOptions(yargs, Object.assign({}, okapiRequired));
   },
   handler: mainHandler(addModuleDescriptorCommand),
 };

--- a/lib/commands/mod/descriptor.js
+++ b/lib/commands/mod/descriptor.js
@@ -14,7 +14,7 @@ function moduleDescriptorCommand(argv, context) {
 }
 
 module.exports = {
-  command: 'descriptor',
+  command: 'descriptor [configFile]',
   describe: 'Generate module descriptors for an app or platform.',
   builder: (yargs) => {
     yargs

--- a/lib/commands/mod/disable.js
+++ b/lib/commands/mod/disable.js
@@ -3,7 +3,7 @@ const importLazy = require('import-lazy')(require);
 const { mainHandler } = importLazy('../../cli/main-handler');
 const Okapi = importLazy('../../okapi');
 const ModuleService = importLazy('../../okapi/module-service');
-const { applyOptions, okapiOptions } = importLazy('../common-options');
+const { applyOptions, moduleIdsStdin, okapiRequired, tenantRequired } = importLazy('../common-options');
 const { stdinArrayHandler } = importLazy('../../cli/stdin-handler');
 
 function disableModuleCommand(argv, context) {
@@ -29,14 +29,10 @@ module.exports = {
   describe: 'Disable modules for a tenant in Okapi',
   builder: (yargs) => {
     yargs
-      .option('ids', {
-        describe: 'Module descriptor ids',
-        type: 'array',
-      })
       .example('$0 mod disable --tenant diku', 'Disable the current ui-module (app context)')
       .example('$0 mod disable --ids one two --tenant diku', 'Disable module ids "one" and "two" for tenant diku')
       .example('echo one two | $0 mod disable --tenant diku', 'Disable module ids "one" and "two" for tenant diku with stdin');
-    return applyOptions(yargs, Object.assign({}, okapiOptions));
+    return applyOptions(yargs, Object.assign({}, moduleIdsStdin, okapiRequired, tenantRequired));
   },
   handler: mainHandler(stdinArrayHandler('ids', disableModuleCommand)),
 };

--- a/lib/commands/mod/enable.js
+++ b/lib/commands/mod/enable.js
@@ -3,7 +3,7 @@ const importLazy = require('import-lazy')(require);
 const { mainHandler } = importLazy('../../cli/main-handler');
 const Okapi = importLazy('../../okapi');
 const ModuleService = importLazy('../../okapi/module-service');
-const { applyOptions, okapiOptions } = importLazy('../common-options');
+const { applyOptions, moduleIdsStdin, okapiRequired, tenantRequired } = importLazy('../common-options');
 const { stdinArrayHandler } = importLazy('../../cli/stdin-handler');
 
 function enableModuleCommand(argv, context) {
@@ -37,14 +37,10 @@ module.exports = {
   describe: 'Enable an app module descriptor for a tenant in Okapi',
   builder: (yargs) => {
     yargs
-      .option('ids', {
-        describe: 'Module descriptor ids',
-        type: 'array',
-      })
       .example('$0 mod enable --tenant diku', 'Enable the current ui-module (app context)')
       .example('$0 mod enable --ids one two --tenant diku', 'Enable module ids "one" and "two" for tenant diku')
       .example('echo one two | $0 mod enable --tenant diku', 'Enable module ids "one" and "two" for tenant diku with stdin');
-    return applyOptions(yargs, Object.assign({}, okapiOptions));
+    return applyOptions(yargs, Object.assign({}, moduleIdsStdin, okapiRequired, tenantRequired));
   },
   handler: mainHandler(stdinArrayHandler('ids', enableModuleCommand)),
 };

--- a/lib/commands/mod/install.js
+++ b/lib/commands/mod/install.js
@@ -3,7 +3,7 @@ const importLazy = require('import-lazy')(require);
 const { mainHandler } = importLazy('../../cli/main-handler');
 const Okapi = importLazy('../../okapi');
 const ModuleService = importLazy('../../okapi/module-service');
-const { applyOptions, okapiOptions } = importLazy('../common-options');
+const { applyOptions, moduleIdsStdin, okapiOptions } = importLazy('../common-options');
 const { stdinArrayHandler } = importLazy('../../cli/stdin-handler');
 
 
@@ -16,7 +16,7 @@ function installModulesCommand(argv, context) {
   const okapi = new Okapi(argv.okapi, argv.tenant);
   const moduleService = new ModuleService(okapi, context);
 
-  return moduleService.installModulesForTenant(argv.ids, argv.tenant)
+  return moduleService.installModulesForTenant(argv.ids, argv.tenant, argv.simulate)
     .then((response) => {
       console.log(response);
     });
@@ -27,17 +27,13 @@ module.exports = {
   describe: 'Enable, disable, or upgrade one or more modules for a tenant in Okapi (work in progress)',
   builder: (yargs) => {
     yargs
-      .option('ids', {
-        describe: 'Module descriptor ids',
-        type: 'array'
-      })
       .option('simulate', {
         describe: 'Perform a dry run',
         type: 'boolean'
       })
       .example('$0 mod install --ids one two --tenant diku', 'Install module ids "one" and "two"')
       .example('echo one two | $0 mod install --tenant diku', 'Install module ids "one" and "two" using stdin');
-    return applyOptions(yargs, Object.assign({}, okapiOptions));
+    return applyOptions(yargs, Object.assign({}, moduleIdsStdin, okapiOptions));
   },
   handler: mainHandler(stdinArrayHandler('ids', installModulesCommand)),
 };

--- a/lib/commands/mod/install.js
+++ b/lib/commands/mod/install.js
@@ -4,7 +4,7 @@ const { mainHandler } = importLazy('../../cli/main-handler');
 const Okapi = importLazy('../../okapi');
 const OkapiError = importLazy('../../okapi/okapi-error');
 const ModuleService = importLazy('../../okapi/module-service');
-const { applyOptions, moduleIdsStdin, okapiOptions } = importLazy('../common-options');
+const { applyOptions, moduleIdsStdin, okapiRequired, tenantRequired } = importLazy('../common-options');
 const { stdinArrayHandler } = importLazy('../../cli/stdin-handler');
 
 
@@ -48,7 +48,7 @@ module.exports = {
       })
       .example('$0 mod install --ids one two --tenant diku', 'Install module ids "one" and "two"')
       .example('echo one two | $0 mod install --tenant diku', 'Install module ids "one" and "two" using stdin');
-    return applyOptions(yargs, Object.assign({}, moduleIdsStdin, okapiOptions));
+    return applyOptions(yargs, Object.assign({}, moduleIdsStdin, okapiRequired, tenantRequired ));
   },
   handler: mainHandler(stdinArrayHandler('ids', installModulesCommand)),
 };

--- a/lib/commands/mod/install.js
+++ b/lib/commands/mod/install.js
@@ -19,7 +19,8 @@ function installModulesCommand(argv, context) {
   const options = {
     deploy: argv.deploy,
     simulate: argv.simulate,
-    preRelease: argv.preRelease
+    preRelease: argv.preRelease,
+    action: argv.action,
   };
 
   const promise = options.simulate
@@ -55,6 +56,12 @@ module.exports = {
         describe: 'Simulate only',
         type: 'boolean',
         default: false,
+      })
+      .option('action', {
+        describe: 'Action ',
+        type: 'string',
+        choices: ['enable', 'disable'],
+        default: 'enable',
       })
       .option('deploy', {
         describe: 'Deploy modules',

--- a/lib/commands/mod/install.js
+++ b/lib/commands/mod/install.js
@@ -2,6 +2,7 @@ const importLazy = require('import-lazy')(require);
 
 const { mainHandler } = importLazy('../../cli/main-handler');
 const Okapi = importLazy('../../okapi');
+const OkapiError = importLazy('../../okapi/okapi-error');
 const ModuleService = importLazy('../../okapi/module-service');
 const { applyOptions, moduleIdsStdin, okapiOptions } = importLazy('../common-options');
 const { stdinArrayHandler } = importLazy('../../cli/stdin-handler');
@@ -19,6 +20,20 @@ function installModulesCommand(argv, context) {
   return moduleService.installModulesForTenant(argv.ids, argv.tenant, argv.simulate)
     .then((response) => {
       console.log(response);
+    })
+    .catch((error) => {
+      if (error instanceof OkapiError) {
+        const match = argv.ids.find(id => id === error.message);
+        if (match) {
+          console.log(`Module descriptor ${error.message} does not exist in Okapi`);
+        } else if (error.statusCode < 500 && error.message) {
+          console.log(error.message);
+        } else {
+          throw error;
+        }
+      } else {
+        throw error;
+      }
     });
 }
 

--- a/lib/commands/mod/install.js
+++ b/lib/commands/mod/install.js
@@ -48,7 +48,7 @@ module.exports = {
       })
       .example('$0 mod install --ids one two --tenant diku', 'Install module ids "one" and "two"')
       .example('echo one two | $0 mod install --tenant diku', 'Install module ids "one" and "two" using stdin');
-    return applyOptions(yargs, Object.assign({}, moduleIdsStdin, okapiRequired, tenantRequired ));
+    return applyOptions(yargs, Object.assign({}, moduleIdsStdin, okapiRequired, tenantRequired));
   },
   handler: mainHandler(stdinArrayHandler('ids', installModulesCommand)),
 };

--- a/lib/commands/mod/install.js
+++ b/lib/commands/mod/install.js
@@ -16,8 +16,17 @@ function installModulesCommand(argv, context) {
 
   const okapi = new Okapi(argv.okapi, argv.tenant);
   const moduleService = new ModuleService(okapi, context);
+  const options = {
+    deploy: argv.deploy,
+    simulate: argv.simulate,
+    preRelease: argv.preRelease
+  };
 
-  return moduleService.installModulesForTenant(argv.ids, argv.tenant, argv.simulate)
+  const promise = options.simulate
+    ? moduleService.simulateInstallModulesForTenant(argv.ids, argv.tenant, options)
+    : moduleService.installModulesForTenant(argv.ids, argv.tenant, options);
+
+  return promise
     .then((response) => {
       console.log(response);
     })
@@ -43,8 +52,19 @@ module.exports = {
   builder: (yargs) => {
     yargs
       .option('simulate', {
-        describe: 'Perform a dry run',
-        type: 'boolean'
+        describe: 'Simulate only',
+        type: 'boolean',
+        default: false,
+      })
+      .option('deploy', {
+        describe: 'Deploy modules',
+        type: 'boolean',
+        default: false,
+      })
+      .option('preRelease', {
+        describe: 'Include pre-release modules',
+        type: 'boolean',
+        default: true,
       })
       .example('$0 mod install --ids one two --tenant diku', 'Install module ids "one" and "two"')
       .example('echo one two | $0 mod install --tenant diku', 'Install module ids "one" and "two" using stdin');

--- a/lib/commands/mod/install.js
+++ b/lib/commands/mod/install.js
@@ -49,16 +49,16 @@ function installModulesCommand(argv, context) {
 
 module.exports = {
   command: 'install',
-  describe: 'Enable, disable, or upgrade one or more modules for a tenant in Okapi (work in progress)',
+  describe: 'Enable, disable, and optionally deploy one or more modules for a tenant in Okapi',
   builder: (yargs) => {
     yargs
       .option('simulate', {
-        describe: 'Simulate only',
+        describe: 'Simulate operation',
         type: 'boolean',
         default: false,
       })
       .option('action', {
-        describe: 'Action ',
+        describe: 'Action to perform on modules',
         type: 'string',
         choices: ['enable', 'disable'],
         default: 'enable',
@@ -73,7 +73,8 @@ module.exports = {
         type: 'boolean',
         default: true,
       })
-      .example('$0 mod install --ids one two --tenant diku', 'Install module ids "one" and "two"')
+      .example('$0 mod install --ids one two --tenant diku --deploy', 'Install and deploy module ids "one" and "two"')
+      .example('$0 mod install --ids one two --tenant diku --action disable', 'Disable module ids "one" and "two"')
       .example('echo one two | $0 mod install --tenant diku', 'Install module ids "one" and "two" using stdin');
     return applyOptions(yargs, Object.assign({}, moduleIdsStdin, okapiRequired, tenantRequired));
   },

--- a/lib/commands/mod/list.js
+++ b/lib/commands/mod/list.js
@@ -3,7 +3,7 @@ const importLazy = require('import-lazy')(require);
 const { mainHandler } = importLazy('../../cli/main-handler');
 const Okapi = importLazy('../../okapi');
 const ModuleService = importLazy('../../okapi/module-service');
-const { applyOptions, okapiOptions } = importLazy('../common-options');
+const { applyOptions, okapiRequired, tenantOption } = importLazy('../common-options');
 
 
 function listModuleCommand(argv, context) {
@@ -32,7 +32,7 @@ module.exports = {
       .example('$0 mod list --tenant diku', 'List enabled module ids for tenant diku')
       .example('$0 mod list', 'List all available module ids in Okapi')
       .example('$0 mod list --no-tenant', 'List available module ids in Okapi (overriding any tenant set via config)');
-    return applyOptions(yargs, Object.assign({}, okapiOptions));
+    return applyOptions(yargs, Object.assign({}, okapiRequired, tenantOption));
   },
   handler: mainHandler(listModuleCommand),
 };

--- a/lib/commands/mod/pull.js
+++ b/lib/commands/mod/pull.js
@@ -3,7 +3,7 @@ const importLazy = require('import-lazy')(require);
 const { mainHandler } = importLazy('../../cli/main-handler');
 const Okapi = importLazy('../../okapi');
 const ModuleService = importLazy('../../okapi/module-service');
-const { applyOptions, okapiOptions } = importLazy('../common-options');
+const { applyOptions, okapiRequired } = importLazy('../common-options');
 
 
 function pullModuleDescriptorsCommand(argv, context) {
@@ -31,7 +31,7 @@ module.exports = {
         required: true,
       })
       .example('$0 mod pull --okapi http://localhost:9130 --remote http://folio-registry.aws.indexdata.com', 'Pull module descriptors from remote Okapi');
-    return applyOptions(yargs, Object.assign({}, okapiOptions));
+    return applyOptions(yargs, Object.assign({}, okapiRequired));
   },
   handler: mainHandler(pullModuleDescriptorsCommand),
 };

--- a/lib/commands/mod/pull.js
+++ b/lib/commands/mod/pull.js
@@ -1,0 +1,37 @@
+const importLazy = require('import-lazy')(require);
+
+const { mainHandler } = importLazy('../../cli/main-handler');
+const Okapi = importLazy('../../okapi');
+const ModuleService = importLazy('../../okapi/module-service');
+const { applyOptions, okapiOptions } = importLazy('../common-options');
+
+
+function pullModuleDescriptorsCommand(argv, context) {
+  const okapi = new Okapi(argv.okapi, argv.tenant);
+  const moduleService = new ModuleService(okapi, context);
+
+  return moduleService.pullModuleDescriptorsFromRemote(argv.remote)
+    .then((response) => {
+      if (Array.isArray(response)) {
+        response.forEach(mod => console.log(mod));
+      } else {
+        console.log(response);
+      }
+    });
+}
+
+module.exports = {
+  command: 'pull',
+  describe: 'Pull module descriptors from a remote okapi',
+  builder: (yargs) => {
+    yargs
+      .option('remote', {
+        describe: 'Remote Okapi to pull from',
+        type: 'string',
+        required: true,
+      })
+      .example('$0 mod pull --okapi http://localhost:9130 --remote http://folio-registry.aws.indexdata.com', 'Pull module descriptors from remote Okapi');
+    return applyOptions(yargs, Object.assign({}, okapiOptions));
+  },
+  handler: mainHandler(pullModuleDescriptorsCommand),
+};

--- a/lib/commands/mod/remove.js
+++ b/lib/commands/mod/remove.js
@@ -3,7 +3,7 @@ const importLazy = require('import-lazy')(require);
 const { mainHandler } = importLazy('../../cli/main-handler');
 const Okapi = importLazy('../../okapi');
 const ModuleService = importLazy('../../okapi/module-service');
-const { applyOptions, okapiOptions } = importLazy('../common-options');
+const { applyOptions, moduleIdsStdin, okapiRequired } = importLazy('../common-options');
 const { stdinArrayHandler } = importLazy('../../cli/stdin-handler');
 
 
@@ -36,14 +36,10 @@ module.exports = {
   describe: 'Remove a module descriptor from Okapi',
   builder: (yargs) => {
     yargs
-      .option('ids', {
-        describe: 'Module descriptor ids',
-        type: 'array',
-      })
       .example('$0 mod remove', 'Remove ui-module located in current directory')
       .example('$0 mod remove --ids one two', 'Remove module ids "one" and "two" from Okapi')
       .example('echo one two | $0 mod remove', 'Remove module ids "one" and "two" from Okapi with stdin');
-    return applyOptions(yargs, Object.assign({}, okapiOptions));
+    return applyOptions(yargs, Object.assign({}, moduleIdsStdin, okapiRequired));
   },
   handler: mainHandler(stdinArrayHandler('ids', removeModuleDescriptorCommand)),
 };

--- a/lib/commands/mod/remove.js
+++ b/lib/commands/mod/remove.js
@@ -4,36 +4,46 @@ const { mainHandler } = importLazy('../../cli/main-handler');
 const Okapi = importLazy('../../okapi');
 const ModuleService = importLazy('../../okapi/module-service');
 const { applyOptions, okapiOptions } = importLazy('../common-options');
+const { stdinArrayHandler } = importLazy('../../cli/stdin-handler');
 
 
 function removeModuleDescriptorCommand(argv, context) {
-  // check for app context, then load package.json
-  if (context.type !== 'app') {
-    console.log('"mod remove" only works in the APP context');
+  const okapi = new Okapi(argv.okapi, argv.tenant);
+  const moduleService = new ModuleService(okapi);
+  let descriptorIds;
+
+  if (argv.ids) {
+    descriptorIds = argv.ids;
+  } else if (context.type === 'app') {
+    descriptorIds = ModuleService.getModuleDescriptorsFromContext(context).map(descriptor => descriptor.id);
+  } else {
+    console.log('No module descriptor ids provided');
     return Promise.reject();
   }
 
-  const okapi = new Okapi(argv.okapi, argv.tenant);
-  const moduleService = new ModuleService(okapi);
-
-  const descriptors = ModuleService.getModuleDescriptorsFromContext(context);
-  return moduleService.removeModuleDescriptor(descriptors[0])
-    .then((response) => {
+  return moduleService.removeModuleDescriptorIds(descriptorIds)
+    .then((responses) => responses.forEach((response) => {
       if (response.doesNotExist) {
         console.log(`Module descriptor ${response.id} does not exist in Okapi`);
       } else {
         console.log(`Module descriptor ${response.id} removed from Okapi`);
       }
-    });
+    }));
 }
 
 module.exports = {
   command: 'remove',
-  describe: 'Remove an app module descriptor from Okapi',
+  describe: 'Remove a module descriptor from Okapi',
   builder: (yargs) => {
     yargs
-      .example('$0 mod add', '');
+      .option('ids', {
+        describe: 'Module descriptor ids',
+        type: 'array',
+      })
+      .example('$0 mod remove', 'Remove ui-module located in current directory')
+      .example('$0 mod remove --ids one two', 'Remove module ids "one" and "two" from Okapi')
+      .example('echo one two | $0 mod remove', 'Remove module ids "one" and "two" from Okapi with stdin');
     return applyOptions(yargs, Object.assign({}, okapiOptions));
   },
-  handler: mainHandler(removeModuleDescriptorCommand),
+  handler: mainHandler(stdinArrayHandler('ids', removeModuleDescriptorCommand)),
 };

--- a/lib/commands/mod/update.js
+++ b/lib/commands/mod/update.js
@@ -3,7 +3,7 @@ const importLazy = require('import-lazy')(require);
 const { mainHandler } = importLazy('../../cli/main-handler');
 const Okapi = importLazy('../../okapi');
 const ModuleService = importLazy('../../okapi/module-service');
-const { applyOptions, okapiOptions } = importLazy('../common-options');
+const { applyOptions, okapiRequired } = importLazy('../common-options');
 
 
 function updateModuleDescriptorCommand(argv, context) {
@@ -30,8 +30,8 @@ module.exports = {
   describe: 'Update an app module descriptor in Okapi',
   builder: (yargs) => {
     yargs
-      .example('$0 mod update', '');
-    return applyOptions(yargs, Object.assign({}, okapiOptions));
+      .example('$0 mod update', 'Update descriptor for ui-module in current directory');
+    return applyOptions(yargs, Object.assign({}, okapiRequired));
   },
   handler: mainHandler(updateModuleDescriptorCommand),
 };

--- a/lib/commands/mod/view.js
+++ b/lib/commands/mod/view.js
@@ -3,7 +3,7 @@ const importLazy = require('import-lazy')(require);
 const { mainHandler } = importLazy('../../cli/main-handler');
 const Okapi = importLazy('../../okapi');
 const ModuleService = importLazy('../../okapi/module-service');
-const { applyOptions, okapiOptions } = importLazy('../common-options');
+const { applyOptions, moduleIdsStdin, okapiRequired } = importLazy('../common-options');
 const { stdinArrayHandler } = importLazy('../../cli/stdin-handler');
 
 
@@ -30,13 +30,9 @@ module.exports = {
   describe: 'View module descriptors of module ids in Okapi',
   builder: (yargs) => {
     yargs
-      .option('ids', {
-        describe: 'Module descriptor ids',
-        type: 'array',
-      })
       .example('$0 mod view --ids one two', 'View module descriptors for ids "one" and "two"')
       .example('echo one two | $0 mod view', 'View module descriptors for ids "one" and "two" with stdin');
-    return applyOptions(yargs, Object.assign({}, okapiOptions));
+    return applyOptions(yargs, Object.assign({}, moduleIdsStdin, okapiRequired));
   },
   handler: mainHandler(stdinArrayHandler('ids', viewModuleCommand)),
 };

--- a/lib/commands/perm/assign.js
+++ b/lib/commands/perm/assign.js
@@ -32,7 +32,7 @@ function assignPermissionsCommand(argv, context) {
 
 const permOptions = {
   name: {
-    describe: 'Name of the permission',
+    describe: 'Name of the permission (stdin)',
     type: 'string',
     group: 'Permission Options:',
   },

--- a/lib/commands/perm/unassign.js
+++ b/lib/commands/perm/unassign.js
@@ -29,7 +29,7 @@ function unassignPermissionsCommand(argv, context) {
 
 const permOptions = {
   name: {
-    describe: 'Name of the permission',
+    describe: 'Name of the permission (stdin)',
     type: 'string',
     group: 'Permission Options:',
   },

--- a/lib/commands/platform/backend.js
+++ b/lib/commands/platform/backend.js
@@ -99,6 +99,10 @@ module.exports = {
   describe: 'Initialize Okapi backend for a platform (work in progress)',
   builder: (yargs) => {
     yargs
+      .positional('configFile', {
+        describe: 'File containing a Stripes tenant configuration',
+        type: 'string',
+      })
       .option('simulate', {
         describe: 'Simulate install only (does not deploy)',
         type: 'boolean',
@@ -110,18 +114,22 @@ module.exports = {
         default: true,
       })
       .option('remote', {
-        describe: 'Update module descriptors via remote before install',
+        describe: 'Pull module descriptors from remote registry before install',
         type: 'string',
       })
       .option('include', {
-        describe: 'Additional backend module ids to include with install',
+        describe: 'Additional module ids to include with install',
         type: 'array',
       })
       .option('detail', {
         describe: 'Display detailed output',
         type: 'boolean',
         default: false,
-      });
+      })
+      .example('$0 platform backend stripes.config.js', 'Deploy, enable, and/or upgrade modules to support the current platform')
+      .example('$0 platform backend stripes.config.js --simulate --detail', 'View modules that need to enabled/upgraded for the current platform')
+      .example('$0 platform backend stripes.config.js --remote http://folio-registry.aws.indexdata.com', 'Pull module descriptors from remote Okapi prior to install')
+      .example('$0 platform backend stripes.config.js --include one two', 'Include modules "one" and "two" not specified in tenant config');
     return applyOptions(yargs, Object.assign({}, okapiRequired, tenantRequired));
   },
   handler: mainHandler(backendInstallCommand),

--- a/lib/commands/platform/backend.js
+++ b/lib/commands/platform/backend.js
@@ -15,6 +15,11 @@ async function backendInstallCommand(argv, context) {
 
   const okapi = new Okapi(argv.okapi, argv.tenant);
   const moduleService = new ModuleService(okapi, context);
+  const options = {
+    deploy: argv.deploy,
+    simulate: argv.simulate,
+    preRelease: argv.preRelease
+  };
   let descriptorIds = [];
 
   try {
@@ -39,8 +44,8 @@ async function backendInstallCommand(argv, context) {
     console.log(`  Extended with ${descriptorIds.length - originalDescriptorCount} descriptor ids.\n`);
 
     // Simulate run with install
-    console.log(`Installing modules for tenant ${argv.tenant} at ${argv.okapi} (simulation)...`);
-    const simulationResponse = await moduleService.installModulesForTenant(descriptorIds, argv.tenant, true);
+    console.log(`Prepare module install for tenant ${argv.tenant} at ${argv.okapi}...`);
+    const simulationResponse = await moduleService.installModulesForTenant(descriptorIds, argv.tenant, Object.assign({}, options, { simulate: true }));
 
     // Report current results
     // TODO: Return summary from service
@@ -48,34 +53,41 @@ async function backendInstallCommand(argv, context) {
     const enable = simulationResponse.filter(item => item.action === 'enable' && !item.from).length;
     const upToDate = simulationResponse.filter(item => item.action === 'uptodate').length;
     console.log(`  Actions summary: ${enable} to enable, ${upgrade} to upgrade, ${upToDate} up to date\n`);
-    console.log(simulationResponse);
 
-    // Deploy back-end
-    console.log(`Deploying backend modules for tenant ${argv.tenant} at ${argv.okapi} (this may take a while)...`);
-    const deployBackendResponse = await moduleService.deployBackendModulesForTenantWithActions(simulationResponse, argv.tenant);
-    console.log(deployBackendResponse);
+    if (options.simulate) {
+      console.log('Simulation response:');
+      console.log(simulationResponse);
+    } else {
+      // Deploy back-end
+      console.log(`Deploying backend modules for tenant ${argv.tenant} at ${argv.okapi} (this may take a while)...`);
+      const deployBackendResponse = await moduleService.deployBackendModulesForTenantWithActions(simulationResponse, argv.tenant, options);
+      console.log(deployBackendResponse);
+      console.log('\n');
 
-    // Post front-end
-    console.log(`Posting frontend modules for tenant ${argv.tenant} at ${argv.okapi}...`);
-    const postFrontendResponse = await moduleService.installFrontendModulesForTenantWithActions(simulationResponse, argv.tenant);
-    console.log(postFrontendResponse);
+      // Post front-end
+      console.log(`Posting frontend modules for tenant ${argv.tenant} at ${argv.okapi}...`);
+      const postFrontendResponse = await moduleService.installFrontendModulesForTenantWithActions(simulationResponse, argv.tenant, options);
+      console.log(postFrontendResponse);
+      console.log('\n');
+    }
 
     // Clean-up
-
-    return Promise.resolve();
   } catch (error) {
     if (error instanceof OkapiError) {
       const match = descriptorIds.find(id => id === error.message);
       if (match) {
         console.log(`Module descriptor ${error.message} does not exist in Okapi`);
-        return Promise.resolve();
       } else if (error.statusCode < 500 && error.message) {
         console.log(error.message);
-        return Promise.resolve();
+      } else {
+        console.log('ERROR: Okapi responded with:');
+        console.log(`  ${error.statusCode} ${error.statusText}: "${error.message}"`);
       }
+    } else {
+      Promise.reject(error);
     }
-    return Promise.reject(error);
   }
+  return Promise.resolve();
 }
 
 module.exports = {
@@ -84,8 +96,14 @@ module.exports = {
   builder: (yargs) => {
     yargs
       .option('simulate', {
-        describe: 'Perform a dry run',
-        type: 'boolean'
+        describe: 'Simulate install only (does not deploy)',
+        type: 'boolean',
+        default: false,
+      })
+      .option('preRelease', {
+        describe: 'Include pre-release modules',
+        type: 'boolean',
+        default: true,
       })
       .option('remote', {
         describe: 'Update module descriptors via remote before install',

--- a/lib/commands/platform/backend.js
+++ b/lib/commands/platform/backend.js
@@ -7,6 +7,21 @@ const ModuleService = importLazy('../../okapi/module-service');
 const { applyOptions, okapiRequired, tenantRequired } = importLazy('../common-options');
 
 
+function displayActionResults(response, isDetailView, isSimulation) {
+  const upgrade = response.filter(item => item.action === 'enable' && item.from).length;
+  const enable = response.filter(item => item.action === 'enable' && !item.from).length;
+  const upToDate = response.filter(item => item.action === 'uptodate').length;
+
+  if (isDetailView) {
+    console.log(response);
+    console.log();
+  } else if (isSimulation) {
+    console.log(`  Summary: ${enable} to enable, ${upgrade} to upgrade, ${upToDate} up to date.\n`);
+  } else {
+    console.log(`  Summary: ${enable} enabled, ${upgrade} upgraded, ${upToDate} up to date.\n`);
+  }
+}
+
 async function backendInstallCommand(argv, context) {
   if (context.type !== 'platform') {
     console.log('"platform backend" only works in the PLATFORM context');
@@ -34,44 +49,33 @@ async function backendInstallCommand(argv, context) {
     console.log(`Generating module descriptors for ${context.moduleName}...`);
     descriptorIds = ModuleService.getModuleDescriptorsFromContext(context, argv.configFile, argv.strict)
       .map(descriptor => descriptor.id);
-
-    // Report on progress
     const originalDescriptorCount = descriptorIds.length;
-    console.log(`  ${originalDescriptorCount} descriptor ids found in platform.`);
 
     // Supplement module descriptors based on existence of other modules in the platform
     descriptorIds = ModuleService.extendModuleDescriptorIds(descriptorIds, argv.include);
-    console.log(`  Extended with ${descriptorIds.length - originalDescriptorCount} descriptor ids.\n`);
+    if (argv.detail) {
+      console.log(descriptorIds);
+      console.log();
+    } else {
+      console.log(`  Summary: ${originalDescriptorCount} platform descriptor ids, ${descriptorIds.length - originalDescriptorCount} extended descriptor ids.\n`);
+    }
 
     // Simulate run with install
     console.log(`Prepare module install for tenant ${argv.tenant} at ${argv.okapi}...`);
     const simulationResponse = await moduleService.simulateInstallModulesForTenant(descriptorIds, argv.tenant, options);
+    displayActionResults(simulationResponse, argv.detail, true);
 
-    // Report current results
-    // TODO: Return summary from service
-    const upgrade = simulationResponse.filter(item => item.action === 'enable' && item.from).length;
-    const enable = simulationResponse.filter(item => item.action === 'enable' && !item.from).length;
-    const upToDate = simulationResponse.filter(item => item.action === 'uptodate').length;
-    console.log(`  Actions summary: ${enable} to enable, ${upgrade} to upgrade, ${upToDate} up to date\n`);
-
-    if (options.simulate) {
-      console.log('Simulation response:');
-      console.log(simulationResponse);
-    } else {
+    if (!options.simulate) {
       // Deploy back-end
       console.log(`Deploying backend modules for tenant ${argv.tenant} at ${argv.okapi} (this may take a while)...`);
       const deployBackendResponse = await moduleService.deployBackendModulesForTenantWithActions(simulationResponse, argv.tenant, options);
-      console.log(deployBackendResponse);
-      console.log('\n');
+      displayActionResults(deployBackendResponse, argv.detail);
 
       // Post front-end
       console.log(`Posting frontend modules for tenant ${argv.tenant} at ${argv.okapi}...`);
       const postFrontendResponse = await moduleService.installFrontendModulesForTenantWithActions(simulationResponse, argv.tenant, options);
-      console.log(postFrontendResponse);
-      console.log('\n');
+      displayActionResults(postFrontendResponse, argv.detail);
     }
-
-    // Clean-up
   } catch (error) {
     if (error instanceof OkapiError) {
       const match = descriptorIds.find(id => id === error.message);
@@ -112,6 +116,11 @@ module.exports = {
       .option('include', {
         describe: 'Additional backend module ids to include with install',
         type: 'array',
+      })
+      .option('detail', {
+        describe: 'Display detailed output',
+        type: 'boolean',
+        default: false,
       });
     return applyOptions(yargs, Object.assign({}, okapiRequired, tenantRequired));
   },

--- a/lib/commands/platform/backend.js
+++ b/lib/commands/platform/backend.js
@@ -1,0 +1,85 @@
+const importLazy = require('import-lazy')(require);
+
+const { mainHandler } = importLazy('../../cli/main-handler');
+const Okapi = importLazy('../../okapi');
+const OkapiError = importLazy('../../okapi/okapi-error');
+const ModuleService = importLazy('../../okapi/module-service');
+const { applyOptions, okapiRequired, tenantRequired } = importLazy('../common-options');
+
+
+async function backendInstallCommand(argv, context) {
+  if (context.type !== 'platform') {
+    console.log('"platform backend" only works in the PLATFORM context');
+    return Promise.reject();
+  }
+
+  const okapi = new Okapi(argv.okapi, argv.tenant);
+  const moduleService = new ModuleService(okapi, context);
+  let descriptorIds = [];
+
+  try {
+    // Pull remote module descriptors
+    if (argv.remote) {
+      console.log(`Pulling latest descriptors from ${argv.remote} ...`);
+      const pullResponse = await moduleService.pullModuleDescriptorsFromRemote(argv.remote);
+      console.log(`  ${pullResponse.length} descriptors added.\n`);
+    }
+
+    // Generate module descriptors
+    console.log(`Generating module descriptors for ${context.moduleName} ...`);
+    descriptorIds = ModuleService.getModuleDescriptorsFromContext(context, argv.configFile, argv.strict)
+      .map(descriptor => descriptor.id);
+
+    // Supplement module descriptors based on existence of other modules in the platform
+    descriptorIds = ModuleService.extendModuleDescriptorIds(descriptorIds, argv.include);
+
+    // Report on progress
+    descriptorIds.forEach(mod => console.log(`  ${mod}`));
+    console.log(`  ${descriptorIds.length} descriptors total.\n`);
+
+    // Simulate run with install
+    console.log(`Installing modules for tenant ${argv.tenant} at ${argv.okapi} (simulation) ...`);
+    const installResponse = await moduleService.installModulesForTenant(descriptorIds, argv.tenant, true);
+
+    // Report current results
+    console.log(installResponse);
+
+    // Cleanup
+
+    return Promise.resolve();
+  } catch (error) {
+    if (error instanceof OkapiError) {
+      const match = descriptorIds.find(id => id === error.message);
+      if (match) {
+        console.log(`Module descriptor ${error.message} does not exist in Okapi`);
+        return Promise.resolve();
+      } else if (error.statusCode < 500 && error.message) {
+        console.log(error.message);
+        return Promise.resolve();
+      }
+    }
+    return Promise.reject(error);
+  }
+}
+
+module.exports = {
+  command: 'backend [configFile]',
+  describe: 'Initialize Okapi backend for a platform (work in progress)',
+  builder: (yargs) => {
+    yargs
+      .option('simulate', {
+        describe: 'Perform a dry run',
+        type: 'boolean'
+      })
+      .option('remote', {
+        describe: 'Update module descriptors via remote before install',
+        type: 'string',
+      })
+      .option('include', {
+        describe: 'Additional backend module ids to include with install',
+        type: 'array',
+      });
+    return applyOptions(yargs, Object.assign({}, okapiRequired, tenantRequired));
+  },
+  handler: mainHandler(backendInstallCommand),
+};

--- a/lib/commands/platform/backend.js
+++ b/lib/commands/platform/backend.js
@@ -20,31 +20,47 @@ async function backendInstallCommand(argv, context) {
   try {
     // Pull remote module descriptors
     if (argv.remote) {
-      console.log(`Pulling latest descriptors from ${argv.remote} ...`);
+      console.log(`Pulling latest descriptors from ${argv.remote}...`);
       const pullResponse = await moduleService.pullModuleDescriptorsFromRemote(argv.remote);
-      console.log(`  ${pullResponse.length} descriptors added.\n`);
+      console.log(`  ${pullResponse.length} descriptors added to Okapi.\n`);
     }
 
     // Generate module descriptors
-    console.log(`Generating module descriptors for ${context.moduleName} ...`);
+    console.log(`Generating module descriptors for ${context.moduleName}...`);
     descriptorIds = ModuleService.getModuleDescriptorsFromContext(context, argv.configFile, argv.strict)
       .map(descriptor => descriptor.id);
 
+    // Report on progress
+    const originalDescriptorCount = descriptorIds.length;
+    console.log(`  ${originalDescriptorCount} descriptor ids found in platform.`);
+
     // Supplement module descriptors based on existence of other modules in the platform
     descriptorIds = ModuleService.extendModuleDescriptorIds(descriptorIds, argv.include);
-
-    // Report on progress
-    descriptorIds.forEach(mod => console.log(`  ${mod}`));
-    console.log(`  ${descriptorIds.length} descriptors total.\n`);
+    console.log(`  Extended with ${descriptorIds.length - originalDescriptorCount} descriptor ids.\n`);
 
     // Simulate run with install
-    console.log(`Installing modules for tenant ${argv.tenant} at ${argv.okapi} (simulation) ...`);
-    const installResponse = await moduleService.installModulesForTenant(descriptorIds, argv.tenant, true);
+    console.log(`Installing modules for tenant ${argv.tenant} at ${argv.okapi} (simulation)...`);
+    const simulationResponse = await moduleService.installModulesForTenant(descriptorIds, argv.tenant, true);
 
     // Report current results
-    console.log(installResponse);
+    // TODO: Return summary from service
+    const upgrade = simulationResponse.filter(item => item.action === 'enable' && item.from).length;
+    const enable = simulationResponse.filter(item => item.action === 'enable' && !item.from).length;
+    const upToDate = simulationResponse.filter(item => item.action === 'uptodate').length;
+    console.log(`  Actions summary: ${enable} to enable, ${upgrade} to upgrade, ${upToDate} up to date\n`);
+    console.log(simulationResponse);
 
-    // Cleanup
+    // Deploy back-end
+    console.log(`Deploying backend modules for tenant ${argv.tenant} at ${argv.okapi} (this may take a while)...`);
+    const deployBackendResponse = await moduleService.deployBackendModulesForTenantWithActions(simulationResponse, argv.tenant);
+    console.log(deployBackendResponse);
+
+    // Post front-end
+    console.log(`Posting frontend modules for tenant ${argv.tenant} at ${argv.okapi}...`);
+    const postFrontendResponse = await moduleService.installFrontendModulesForTenantWithActions(simulationResponse, argv.tenant);
+    console.log(postFrontendResponse);
+
+    // Clean-up
 
     return Promise.resolve();
   } catch (error) {

--- a/lib/commands/platform/backend.js
+++ b/lib/commands/platform/backend.js
@@ -45,7 +45,7 @@ async function backendInstallCommand(argv, context) {
 
     // Simulate run with install
     console.log(`Prepare module install for tenant ${argv.tenant} at ${argv.okapi}...`);
-    const simulationResponse = await moduleService.installModulesForTenant(descriptorIds, argv.tenant, Object.assign({}, options, { simulate: true }));
+    const simulationResponse = await moduleService.simulateInstallModulesForTenant(descriptorIds, argv.tenant, options);
 
     // Report current results
     // TODO: Return summary from service

--- a/lib/environment/inventory.js
+++ b/lib/environment/inventory.js
@@ -70,6 +70,14 @@ function toFolioName(theModule) {
   return `@folio/${moduleName}`;
 }
 
+// Mapping of extra modules based on existence of other modules.
+const backendDescriptorExtras = [
+  { match: ['folio_search', 'folio_inventory'],
+    ids: ['mod-codex-inventory'] },
+  { match: ['folio_search', 'folio_eholdings'],
+    ids: ['mod-codex-ekb'] }
+];
+
 module.exports = {
   uiModules,
   stripesModules,
@@ -78,4 +86,5 @@ module.exports = {
   allModules: uiModules.concat(stripesModules, platforms, otherModules),
   toFolioName,
   moduleDescriptorExtras,
+  backendDescriptorExtras,
 };

--- a/lib/okapi/module-service.js
+++ b/lib/okapi/module-service.js
@@ -168,4 +168,14 @@ module.exports = class ModuleService {
         return Promise.resolve({ id: moduleDescriptor.id, success: true });
       });
   }
+
+  pullModuleDescriptorsFromRemote(remoteUrl) {
+    const remoteUrlPayload = {
+      urls: [remoteUrl],
+    };
+
+    return this.okapi.proxy.pullModuleDescriptorsFromRemote(remoteUrlPayload)
+      .then(response => response.json())
+      .then(data => data.map(mod => mod.id));
+  }
 };

--- a/lib/okapi/module-service.js
+++ b/lib/okapi/module-service.js
@@ -162,12 +162,18 @@ module.exports = class ModuleService {
     return promise.then(response => response.json());
   }
 
-  simulateInstallModulesForTenant(moduleDescriptorIds, tenant) {
-    const modulePayload = moduleDescriptorIds.map(id => {
-      return { id, action: 'enable' };
-    });
-    return this.okapi.proxy.simulateInstallModulesForTenant(modulePayload, tenant)
-      .then(response => response.json());
+  deployBackendModulesForTenantWithActions(moduleDescriptorActions, tenant) {
+    // Filter out front-end modules
+    const moduleActions = moduleDescriptorActions.filter(mod => !mod.id.startsWith('folio_'));
+    const promise = this.okapi.proxy.deployInstallModulesForTenant(moduleActions, tenant);
+    return promise.then(response => response.json());
+  }
+
+  installFrontendModulesForTenantWithActions(moduleDescriptorActions, tenant) {
+    // Filter out back-end modules
+    const moduleActions = moduleDescriptorActions.filter(mod => mod.id.startsWith('folio_'));
+    const promise = this.okapi.proxy.installModulesForTenant(moduleActions, tenant);
+    return promise.then(response => response.json());
   }
 
   // TODO: Handle this more like upgrading a module

--- a/lib/okapi/module-service.js
+++ b/lib/okapi/module-service.js
@@ -157,7 +157,7 @@ module.exports = class ModuleService {
       preRelease: options.preRelease || false,
     };
     const modulePayload = moduleDescriptorIds.map(id => {
-      return { id, action: 'enable' };
+      return { id, action: options.action || 'enable' };
     });
 
     const promise = this.okapi.proxy.installModulesForTenant(modulePayload, tenant, installOptions);
@@ -171,7 +171,7 @@ module.exports = class ModuleService {
       preRelease: options.preRelease || false,
     };
     const modulePayload = moduleDescriptorIds.map(id => {
-      return { id, action: 'enable' };
+      return { id, action: options.action || 'enable' };
     });
 
     const promise = this.okapi.proxy.installModulesForTenant(modulePayload, tenant, simulateOptions);

--- a/lib/okapi/module-service.js
+++ b/lib/okapi/module-service.js
@@ -150,29 +150,57 @@ module.exports = class ModuleService {
       .reduce((promiseChain, currentFunction) => promiseChain.then(currentFunction), Promise.resolve());
   }
 
-  installModulesForTenant(moduleDescriptorIds, tenant, simulate) {
+  installModulesForTenant(moduleDescriptorIds, tenant, options) {
+    const installOptions = {
+      deploy: options.deploy || false,
+      simulate: options.simulate || false,
+      preRelease: options.preRelease || false,
+    };
     const modulePayload = moduleDescriptorIds.map(id => {
       return { id, action: 'enable' };
     });
 
-    const promise = simulate
-      ? this.okapi.proxy.simulateInstallModulesForTenant(modulePayload, tenant)
-      : this.okapi.proxy.installModulesForTenant(modulePayload, tenant);
-
+    const promise = this.okapi.proxy.installModulesForTenant(modulePayload, tenant, installOptions);
     return promise.then(response => response.json());
   }
 
-  deployBackendModulesForTenantWithActions(moduleDescriptorActions, tenant) {
+  simulateInstallModulesForTenant(moduleDescriptorIds, tenant, options) {
+    const simulateOptions = {
+      deploy: false,
+      simulate: true,
+      preRelease: options.preRelease || false,
+    };
+    const modulePayload = moduleDescriptorIds.map(id => {
+      return { id, action: 'enable' };
+    });
+
+    const promise = this.okapi.proxy.installModulesForTenant(modulePayload, tenant, simulateOptions);
+    return promise.then(response => response.json());
+  }
+
+  deployBackendModulesForTenantWithActions(moduleDescriptorActions, tenant, options) {
+    const deployOptions = {
+      deploy: true,
+      simulate: options.simulate || false,
+      preRelease: options.preRelease || false,
+    };
+
     // Filter out front-end modules
     const moduleActions = moduleDescriptorActions.filter(mod => !mod.id.startsWith('folio_'));
-    const promise = this.okapi.proxy.deployInstallModulesForTenant(moduleActions, tenant);
+    const promise = this.okapi.proxy.installModulesForTenant(moduleActions, tenant, deployOptions);
     return promise.then(response => response.json());
   }
 
-  installFrontendModulesForTenantWithActions(moduleDescriptorActions, tenant) {
+  installFrontendModulesForTenantWithActions(moduleDescriptorActions, tenant, options) {
+    const installOptions = {
+      deploy: false,
+      simulate: options.simulate || false,
+      preRelease: options.preRelease || false,
+    };
+
     // Filter out back-end modules
     const moduleActions = moduleDescriptorActions.filter(mod => mod.id.startsWith('folio_'));
-    const promise = this.okapi.proxy.installModulesForTenant(moduleActions, tenant);
+    const promise = this.okapi.proxy.installModulesForTenant(moduleActions, tenant, installOptions);
     return promise.then(response => response.json());
   }
 

--- a/lib/okapi/module-service.js
+++ b/lib/okapi/module-service.js
@@ -60,6 +60,18 @@ module.exports = class ModuleService {
       .catch(resolveIfOkapiSays('module does not exist', { id: moduleDescriptor.id, doesNotExist: true }));
   }
 
+  removeModuleDescriptorIds(moduleDescriptorIds) {
+    return moduleDescriptorIds
+      .map(id => (previousResults) => {
+        const results = previousResults || [];
+        return this.removeModuleDescriptor({ id }).then(result => {
+          results.push(result);
+          return results;
+        });
+      })
+      .reduce((promiseChain, currentFunction) => promiseChain.then(currentFunction), Promise.resolve());
+  }
+
   enableModuleForTenant(moduleDescriptorId, tenant) {
     return this.okapi.proxy.enableModuleForTenant(moduleDescriptorId, tenant)
       .then(() => ({ id: moduleDescriptorId, success: true }))

--- a/lib/okapi/module-service.js
+++ b/lib/okapi/module-service.js
@@ -9,7 +9,7 @@ const { resolveIfOkapiSays } = require('../okapi/okapi-utils');
 const OkapiError = require('./okapi-error');
 const generateModuleDescriptor = require('../cli/generate-module-descriptor');
 const StripesPlatform = require('../platform/stripes-platform');
-const { moduleDescriptorExtras, toFolioName } = require('../environment/inventory');
+const { moduleDescriptorExtras, backendDescriptorExtras, toFolioName } = require('../environment/inventory');
 
 module.exports = class ModuleService {
   constructor(okapiRepository) {
@@ -46,6 +46,21 @@ module.exports = class ModuleService {
 
     const descriptors = packageJsons.map(packageJson => generateModuleDescriptor(packageJson, isStrict));
     return descriptors;
+  }
+
+  static extendModuleDescriptorIds(moduleDescriptorIds, manuallyAdded) {
+    const automaticallyAdded = backendDescriptorExtras.reduce((accumulator, current) => {
+      let found = [];
+      // If we have all the matching prerequisites, more module ids are included
+      if (current.match && current.match.every(name => moduleDescriptorIds.find(id => id.startsWith(name)))) {
+        found = current.ids;
+      }
+      return accumulator.concat(found);
+    }, []);
+
+    // Remove duplicates
+    const idsToAdd = uniq(automaticallyAdded.concat(manuallyAdded || []));
+    return moduleDescriptorIds.concat(idsToAdd);
   }
 
   addModuleDescriptor(moduleDescriptor) {

--- a/lib/okapi/okapi-repository.js
+++ b/lib/okapi/okapi-repository.js
@@ -48,6 +48,10 @@ function simulateInstallModulesForTenant(modulePayload, tenant) {
   return okapiClient.post(`/_/proxy/tenants/${tenant}/install?simulate=true`, modulePayload, noTenantNoToken);
 }
 
+function pullModuleDescriptorsFromRemote(remoteUrlPayload) {
+  return okapiClient.post('_/proxy/pull/modules', remoteUrlPayload, noTenantNoToken);
+}
+
 function assignPermissionToUser(permissionName, userId) {
   return okapiClient.post(`/perms/users/${userId}/permissions?indexField=userId`, { permissionName });
 }
@@ -79,6 +83,7 @@ const okapiRoutes = {
     getModulesForTenant,
     installModulesForTenant,
     simulateInstallModulesForTenant,
+    pullModuleDescriptorsFromRemote,
   },
   perms: {
     assignPermissionToUser,

--- a/lib/okapi/okapi-repository.js
+++ b/lib/okapi/okapi-repository.js
@@ -40,16 +40,8 @@ function getModules() {
   return okapiClient.get('/_/proxy/modules', noTenantNoToken);
 }
 
-function installModulesForTenant(modulePayload, tenant) {
-  return okapiClient.post(`/_/proxy/tenants/${tenant}/install`, modulePayload, noTenantNoToken);
-}
-
-function simulateInstallModulesForTenant(modulePayload, tenant) {
-  return okapiClient.post(`/_/proxy/tenants/${tenant}/install?simulate=true`, modulePayload, noTenantNoToken);
-}
-
-function deployInstallModulesForTenant(modulePayload, tenant) {
-  return okapiClient.post(`/_/proxy/tenants/${tenant}/install?deploy=true`, modulePayload, noTenantNoToken);
+function installModulesForTenant(modulePayload, tenant, options) {
+  return okapiClient.post(`/_/proxy/tenants/${tenant}/install?simulate=${options.simulate}&deploy=${options.deploy}&preRelease=${options.preRelease}`, modulePayload, noTenantNoToken);
 }
 
 function pullModuleDescriptorsFromRemote(remoteUrlPayload) {
@@ -86,8 +78,6 @@ const okapiRoutes = {
     disableModuleForTenant,
     getModulesForTenant,
     installModulesForTenant,
-    simulateInstallModulesForTenant,
-    deployInstallModulesForTenant,
     pullModuleDescriptorsFromRemote,
   },
   perms: {

--- a/lib/okapi/okapi-repository.js
+++ b/lib/okapi/okapi-repository.js
@@ -48,6 +48,10 @@ function simulateInstallModulesForTenant(modulePayload, tenant) {
   return okapiClient.post(`/_/proxy/tenants/${tenant}/install?simulate=true`, modulePayload, noTenantNoToken);
 }
 
+function deployInstallModulesForTenant(modulePayload, tenant) {
+  return okapiClient.post(`/_/proxy/tenants/${tenant}/install?deploy=true`, modulePayload, noTenantNoToken);
+}
+
 function pullModuleDescriptorsFromRemote(remoteUrlPayload) {
   return okapiClient.post('_/proxy/pull/modules', remoteUrlPayload, noTenantNoToken);
 }
@@ -83,6 +87,7 @@ const okapiRoutes = {
     getModulesForTenant,
     installModulesForTenant,
     simulateInstallModulesForTenant,
+    deployInstallModulesForTenant,
     pullModuleDescriptorsFromRemote,
   },
   perms: {


### PR DESCRIPTION
This introduces a new `platform backend` command to facilitate the deployment, enabling, and upgrading of back-end modules in a Vagrant box needed to support a front-end FOLIO platform.  STCLI-15