### PR TITLE
Revert "Declare script name for consistent help output"

### DIFF
--- a/lib/stripes-cli.js
+++ b/lib/stripes-cli.js
@@ -42,7 +42,6 @@ try {
     .example('$0 <command> --help', 'View examples and options for a command')
     .demandCommand()
     .env('STRIPES')
-    .scriptName('stripes')
     .help()
     .showHelpOnFail(false)
     .wrap(yargs.terminalWidth())


### PR DESCRIPTION
This reverts commit 2214bc9f6dd137a9639ed2bca1cdc1b7aef4c682.