### PR TITLE
Remove use of stripes.intl

### DIFF
--- a/resources/ui-app/src/settings/index.js
+++ b/resources/ui-app/src/settings/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FormattedMessage } from 'react-intl';
 import { Settings } from '@folio/stripes/smart-components';
 import GeneralSettings from './general-settings';
 import SomeFeatureSettings from './some-feature-settings';
@@ -13,12 +14,12 @@ export default class <%= componentName %>Settings extends React.Component {
   pages = [
     {
       route: 'general',
-      label: this.props.stripes.intl.formatMessage({ id: '<%= uiAppName %>.settings.general' }),
+      label: <FormattedMessage id="<%= uiAppName %>.settings.general" />,
       component: GeneralSettings,
     },
     {
       route: 'somefeature',
-      label: this.props.stripes.intl.formatMessage({ id: '<%= uiAppName %>.settings.some-feature' }),
+      label: <FormattedMessage id="<%= uiAppName %>.settings.some-feature" />,
       component: SomeFeatureSettings,
     },
   ];


### PR DESCRIPTION
`stripes.intl` is deprecated and will soon be removed from `stripes-core`.

Updates to the preferred `<FormattedMessage>` usage.