### PR TITLE
Remove `stripes-react-hotkeys` option

### DIFF
--- a/lib/environment/inventory.js
+++ b/lib/environment/inventory.js
@@ -32,7 +32,6 @@ const stripesModules = [
   'stripes-connect',
   'stripes-components',
   'stripes-smart-components',
-  'stripes-react-hotkeys',
   'stripes-logger',
   'stripes-form',
   'stripes-core',


### PR DESCRIPTION
# Problem
One of the nuances to yarn workspaces is despite installing devDependencies, they fail to run npm lifecycle scripts like `prepublish` that run at the time of a local install, so linked dependencies within the workspace aren't properly built like they would be if one were using an aliased directory outside of the workspace. 

## Solution
Since
* this isn't common knowledge
* this can be really inconvenient
* `stripes-react-hotkeys` doesn't require an extreme amount of maintenance

Best to just exclude it from the options.