### PR TITLE
STCLI-116 json input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   * `mod remove` now supports multiple descriptor ids
   * Enable/disable and optionally deploy modules via `mod install`
   * Deploy, enable, and upgrade modules for a platform via `platform backend`
+* Support using `mod install` simulate output as input for subsequent calls to command, STCLI-116
 
 
 ## [1.6.0](https://github.com/folio-org/stripes-cli/tree/v1.6.0) (2018-10-19)

--- a/doc/backend-guide.md
+++ b/doc/backend-guide.md
@@ -2,6 +2,8 @@
 
 Stripes CLI offers many commands for interacting with Okapi to manage back-end modules for a tenant.  This guide steps through the process of standing up a back-end to support a unique platform.
 
+> Note: This document is currently a work in progress. Notably, it depends on a Vagrant VM that is not yet published.
+
 * [Prerequisites](#prerequisites)
     * [Create a Vagrant box](#create-a-vagrant-box)
     * [Install a front-end platform](#install-a-front-end-platform)

--- a/doc/backend-guide.md
+++ b/doc/backend-guide.md
@@ -1,0 +1,152 @@
+# Stripes CLI Back-end Guide
+
+Stripes CLI offers many commands for interacting with Okapi to manage back-end modules for a tenant.  This guide steps through the process of standing up a back-end to support a unique platform.
+
+* [Prerequisites](#prerequisites)
+    * [Create a Vagrant box](#create-a-vagrant-box)
+    * [Install a front-end platform](#install-a-front-end-platform)
+    * [Configure the CLI (optional)](#configure-the-cli-optional)
+* [Set up back-end modules](#set-up-back-end-modules)
+    * [Useful variants](#useful-variants)
+* [Set up back-end modules (multi-step)](#set-up-back-end-modules-multi-step)
+    * [Pull modules](#pull-modules)
+    * [Generate front-end module ids](#generate-front-end-module-ids)
+    * [Include additional dependencies](#include-additional-dependencies)
+    * [Perform a dry run](#perform-a-dry-run)
+    * [Perform the back-end deployment](#perform-the-back-end-deployment)
+    * [Post the front-end module descriptors](#post-the-front-end-module-descriptors)
+
+
+## Prerequisites
+
+### Create a Vagrant box
+
+This guide requires the (TODO: new box name) Vagrant box or equivalent.  This VM comes pre-loaded with modules to run [platform-core](https://github.com/folio-org/platform-core) modules.  
+
+TODO: replace TBD with actual VM name
+```
+$ mkdir TBD
+$ cd TBD
+$ vagrant init folio/TBD
+$ vagrant up
+```
+
+See the Stripes development setup guide for information to [update an existing Vagrant box](https://github.com/folio-org/stripes/blob/master/doc/new-development-setup.md#update-your-vagrant-box).
+
+
+### Install a front-end platform
+
+Start by cloning your desired platform, such as [platform-erm](https://github.com/folio-org/platform-erm).
+
+```
+$ git clone https://github.com/folio-org/platform-erm
+$ cd platform-erm
+$ yarn install
+```
+
+### Configure the CLI (optional)
+
+Optionally, create a `.stripesclirc` [configuration file](https://github.com/folio-org/stripes-cli/blob/master/doc/user-guide.md#configuration) to store an Okapi URL and tenant ID. Place your CLI configuration in your platform directory or above.
+
+```
+{
+  "okapi": "http://localhost:9130",
+  "tenant": "diku"
+}
+```
+
+> Tip: Alternatively, [environment variables](https://github.com/folio-org/stripes-cli/blob/master/doc/user-guide.md#environment-variables) can be used.
+
+This step is not required.  It is only a convenience so we don't have to include `--okapi` and `--tenant` options with every command.  For simplicity, the commands in this guide will assume these values are present in a config.  Please remember to provide `--okapi` and `--tenant` on the command line if you choose to skip this step.
+
+> Note: While okapi and tenant values are also present in the tenant config, the CLI commands don't yet consider the tenant config for its Okapi operations (only for build operations). STCLI-117 will address this to avoid the interim duplication.
+
+
+## Set up back-end modules
+
+The following command, run from within your platform directory, will prepare and deploy modules and their dependencies for your tenant via Okapi's `/_/proxy/tenants/{tenant_id}/install` endpoint.
+
+```
+$ stripes platform backend stripes.config.js --remote http://folio-registry.aws.indexdata.com
+```
+
+When running this command, the following operations are performed by the CLI and Okapi:
+- Given a `--remote <url>` (optional), Okapi's module descriptors are first updated with the latest from the remote registry.
+- Generate module descriptor ids with the tenant config `stripes.config.js` and the yarn installed front-end modules
+- Append those ids with additional known dependencies.  For example, `mod-codex-inventory` is included if the platform includes `folio_search` and `folio_inventory`.
+- Perform a dry-run install and reports a summary
+- Deploy and enable the back-end modules
+- Post the front-end modules descriptors
+
+### Useful variants
+
+Bypass updating module descriptors from a remote registry by omitting `--remote`.
+```
+$ stripes platform backend stripes.config.js
+```
+
+Conclude the operation with the dry-run simulation by adding, `--simulate`.  Optionally add `--detail` to view the Okapi response.
+```
+$ stripes platform backend stripes.config.js --simulate --detail
+```
+
+Include additional modules with `--inlcude` and supply a space-separated list of module ids.
+```
+$ stripes platform backend stripes.config.js --include mod-x mod-y
+```
+
+
+## Set up back-end modules (multi-step)
+
+For more granular control or to better observe the intermediate operations above, the following individual commands can be performed to achieve the same result.
+
+### Pull modules
+Your Vagrant box will only have module descriptors available for the modules that it came pre-built with.  The `mod pull` command will instruct Okapi to download the latest module descriptor ids from a remote registry.
+
+```
+$ stripes mod pull --remote http://folio-registry.aws.indexdata.com
+```
+ 
+### Generate front-end module ids
+
+This will take the tenant config, `stripes.config.js` and convert the selected modules into module descriptor ids.  Additional front-end `stripes-*` modules will be included like `stripes-core`.
+```
+$ stripes mod descriptor stripes.config.js > my-module-ids
+```
+
+### Include additional dependencies
+
+While `stripes platform backend` offers some logic to dynamically append a few module ids that are not otherwise required by a front-end platform, the CLI doesn't currently offer a stand-alone command to do the same.  Manually add any module ids that you know you need, but are not pulled as a dependency of other modules.  Simply edit the prior output file to append the desired ids.
+
+```
+$ cat >> my-module-ids << 'EOF'
+mod-codex-inventory
+mod-x
+mod-y
+EOF
+```
+
+### Perform a dry run
+
+Using the `my-module-ids` file from the prior command as input, pipe the list to `stripes mod install` with the `--simulate` option set.  This will call Okapi to generate a list of the necessary dependencies and their actions, such as enabling or upgrading, needed.  Save this output to a file as it will be used in the next steps.
+
+```
+$ cat my-module-ids | stripes mod install --simulate > my-module-actions
+```
+
+### Perform the back-end deployment
+
+Using the output from the `--simulate` dry run, filter the results for back-end modules.  For this you can pipe your output through the `stripes mod filter` command. Then pass the filtered results onto `stripes mod install` with the `--deploy` option.
+
+```
+$ cat my-module-actions | stripes mod filter --back | stripes mod install --deploy
+```
+
+
+### Post the front-end module descriptors
+
+Using the same output from the dry run, this time filter the results for front-end modules only. Pass the results to `stripes mod install` (without `--deploy`) enable them for the tenant.
+
+```
+$ cat my-module-actions | stripes mod filter --front | stripes mod install
+```

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -35,6 +35,7 @@ This following command documentation is largely generated from the CLI's own bui
     * [`mod install` command](#mod-install-command)
     * [`mod view` command](#mod-view-command)
     * [`mod pull` command](#mod-pull-command)
+    * [`mod filter` command](#mod-filter-command)
 * [`perm` command](#perm-command)
     * [`perm create` command](#perm-create-command)
     * [`perm assign` command](#perm-assign-command)
@@ -668,6 +669,7 @@ Sub-commands:
 * `stripes mod descriptor`
 * `stripes mod disable`
 * `stripes mod enable`
+* `stripes mod filter`
 * `stripes mod install`
 * `stripes mod list`
 * `stripes mod pull`
@@ -945,6 +947,31 @@ Examples:
 Pull module descriptors from remote Okapi:
 ```
 stripes mod pull --okapi http://localhost:9130 --remote http://folio-registry.aws.indexdata.com
+```
+
+### `mod filter` command
+
+Filter module descriptors
+
+Usage:
+```
+stripesx mod filter
+```
+
+Option | Description | Type | Notes
+---|---|---|---
+`--front` | Front-end modules only | boolean |
+`--back` | Back-end modules only | boolean |
+
+Examples:
+
+Filter front-end module ids:
+```
+echo mod-one folio_two stripesx mod filter --front
+```
+Filter back-end module ids:
+```
+echo mod-one folio_two stripesx mod filter --back
 ```
 
 ## `perm` command

--- a/lib/cli/stdin-handler.js
+++ b/lib/cli/stdin-handler.js
@@ -35,8 +35,26 @@ function stdinArrayHandler(name, nextHandler) {
   };
 }
 
+// Parse stdin as either JSON or an array of whitespace
+function stdinArrayOrJsonHandler(name, nextHandler) {
+  return (argv, ctx) => {
+    return getStdin().then(stdin => {
+      if (stdin) {
+        // Simple check for starting character of '{' or '[' to determine how to handle the data
+        if (stdin.match(/^\s*[{[]/)) {
+          argv[name] = JSON.parse(stdin);
+        } else {
+          argv[name] = stdin.trim().split(/\s+/);
+        }
+      }
+      return nextHandler(argv, ctx);
+    });
+  };
+}
+
 module.exports = {
   stdinStringHandler,
   stdinJsonHandler,
   stdinArrayHandler,
+  stdinArrayOrJsonHandler,
 };

--- a/lib/commands/mod/filter.js
+++ b/lib/commands/mod/filter.js
@@ -1,0 +1,52 @@
+const importLazy = require('import-lazy')(require);
+
+const { mainHandler } = importLazy('../../cli/main-handler');
+const Okapi = importLazy('../../okapi');
+const ModuleService = importLazy('../../okapi/module-service');
+const { stdinArrayOrJsonHandler } = importLazy('../../cli/stdin-handler');
+
+
+function filterModulesCommand(argv, context) {
+  const okapi = new Okapi(argv.okapi, argv.tenant);
+  const moduleService = new ModuleService(okapi, context);
+
+  if (!argv.front && !argv.back) {
+    console.log('A filter must be specified');
+    return;
+  }
+
+  const filtered = argv.front
+    ? moduleService.filterFrontendModules(argv.ids)
+    : moduleService.filterBackendModules(argv.ids);
+
+  // Supports both an array of ids as well as an array of objects with actions
+  if (filtered[0].id) {
+    console.log(JSON.stringify(filtered, null, 2));
+  } else {
+    filtered.forEach(mod => console.log(mod));
+  }
+}
+
+module.exports = {
+  command: 'filter',
+  describe: 'Filter module descriptors',
+  builder: (yargs) => {
+    yargs
+      .option('front', {
+        describe: 'Front-end modules only',
+        type: 'boolean',
+        conflicts: 'back',
+        default: undefined,
+      })
+      .option('back', {
+        describe: 'Back-end modules only',
+        type: 'boolean',
+        conflicts: 'front',
+        default: undefined,
+      })
+      .example('echo mod-one folio_two $0 mod filter --front', 'Filter front-end module ids')
+      .example('echo mod-one folio_two $0 mod filter --back', 'Filter back-end module ids');
+    return yargs;
+  },
+  handler: mainHandler(stdinArrayOrJsonHandler('ids', filterModulesCommand)),
+};

--- a/lib/commands/mod/install.js
+++ b/lib/commands/mod/install.js
@@ -5,7 +5,7 @@ const Okapi = importLazy('../../okapi');
 const OkapiError = importLazy('../../okapi/okapi-error');
 const ModuleService = importLazy('../../okapi/module-service');
 const { applyOptions, moduleIdsStdin, okapiRequired, tenantRequired } = importLazy('../common-options');
-const { stdinArrayHandler } = importLazy('../../cli/stdin-handler');
+const { stdinArrayOrJsonHandler } = importLazy('../../cli/stdin-handler');
 
 
 function installModulesCommand(argv, context) {
@@ -82,5 +82,5 @@ module.exports = {
       .example('echo one two | $0 mod install --tenant diku', 'Install module ids "one" and "two" using stdin');
     return applyOptions(yargs, Object.assign({}, moduleIdsStdin, okapiRequired, tenantRequired));
   },
-  handler: mainHandler(stdinArrayHandler('ids', installModulesCommand)),
+  handler: mainHandler(stdinArrayOrJsonHandler('ids', installModulesCommand)),
 };

--- a/lib/commands/mod/install.js
+++ b/lib/commands/mod/install.js
@@ -29,7 +29,11 @@ function installModulesCommand(argv, context) {
 
   return promise
     .then((response) => {
-      console.log(response);
+      try {
+        console.log(JSON.stringify(response, null, 2));
+      } catch (err) {
+        console.log(response);
+      }
     })
     .catch((error) => {
       if (error instanceof OkapiError) {

--- a/lib/okapi/module-service.js
+++ b/lib/okapi/module-service.js
@@ -178,6 +178,24 @@ module.exports = class ModuleService {
     return promise.then(response => response.json());
   }
 
+  filterFrontendModules(actionsOrIds) {
+    const isActions = actionsOrIds[0].id;
+    if (isActions) {
+      return actionsOrIds.filter(mod => mod.id.startsWith('folio_'));
+    } else {
+      return actionsOrIds.filter(mod => mod.startsWith('folio_'));
+    }
+  }
+
+  filterBackendModules(actionsOrIds) {
+    const isActions = actionsOrIds[0].id;
+    if (isActions) {
+      return actionsOrIds.filter(mod => !mod.id.startsWith('folio_'));
+    } else {
+      return actionsOrIds.filter(mod => !mod.startsWith('folio_'));
+    }
+  }
+
   deployBackendModulesForTenantWithActions(moduleDescriptorActions, tenant, options) {
     const deployOptions = {
       deploy: true,
@@ -186,7 +204,7 @@ module.exports = class ModuleService {
     };
 
     // Filter out front-end modules
-    const moduleActions = moduleDescriptorActions.filter(mod => !mod.id.startsWith('folio_'));
+    const moduleActions = this.filterFrontendModules(moduleDescriptorActions);
     const promise = this.okapi.proxy.installModulesForTenant(moduleActions, tenant, deployOptions);
     return promise.then(response => response.json());
   }
@@ -199,7 +217,7 @@ module.exports = class ModuleService {
     };
 
     // Filter out back-end modules
-    const moduleActions = moduleDescriptorActions.filter(mod => mod.id.startsWith('folio_'));
+    const moduleActions = this.filterBackendModules(moduleDescriptorActions);
     const promise = this.okapi.proxy.installModulesForTenant(moduleActions, tenant, installOptions);
     return promise.then(response => response.json());
   }

--- a/lib/okapi/module-service.js
+++ b/lib/okapi/module-service.js
@@ -150,16 +150,32 @@ module.exports = class ModuleService {
       .reduce((promiseChain, currentFunction) => promiseChain.then(currentFunction), Promise.resolve());
   }
 
+  // Converts an array of module descriptor ids into a payload for okapi's /_/proxy/tenants/{tenant}/install
+  // This also accepts an array of objects containing module descriptor ids and actions so that
+  // the output of one request can be used as input for another.
+  _generateInstallPayload(actionsOrIds, defaultAction) {
+    const isActions = actionsOrIds[0].id;
+    if (isActions) {
+      // We already have objects, so just apply a default action if necessary
+      return actionsOrIds.map(mod => {
+        mod.action = mod.action || defaultAction || 'enable';
+        return mod;
+      });
+    } else {
+      // An array of ids only, so map to objects with an action
+      return actionsOrIds.map(id => {
+        return { id, action: defaultAction || 'enable' };
+      });
+    }
+  }
+
   installModulesForTenant(moduleDescriptorIds, tenant, options) {
     const installOptions = {
       deploy: options.deploy || false,
       simulate: options.simulate || false,
       preRelease: options.preRelease || false,
     };
-    const modulePayload = moduleDescriptorIds.map(id => {
-      return { id, action: options.action || 'enable' };
-    });
-
+    const modulePayload = this._generateInstallPayload(moduleDescriptorIds, options.action);
     const promise = this.okapi.proxy.installModulesForTenant(modulePayload, tenant, installOptions);
     return promise.then(response => response.json());
   }
@@ -170,10 +186,7 @@ module.exports = class ModuleService {
       simulate: true,
       preRelease: options.preRelease || false,
     };
-    const modulePayload = moduleDescriptorIds.map(id => {
-      return { id, action: options.action || 'enable' };
-    });
-
+    const modulePayload = this._generateInstallPayload(moduleDescriptorIds, options.action);
     const promise = this.okapi.proxy.installModulesForTenant(modulePayload, tenant, simulateOptions);
     return promise.then(response => response.json());
   }


### PR DESCRIPTION
This adds support to consume `mod install` simulate output as input for subsequent calls to `mod install`.  This change, along with a new `mod filter` command, enables the CLI to be used to follow along with the single-server install instructions.  A new CLI back-end guide has been drafted to demonstrate usage.

Refs STCLI-15

