### PR TITLE
STCLI-121 use correct relative path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   * `mod remove` now supports multiple descriptor ids
   * Enable/disable and optionally deploy modules via `mod install`
   * Deploy, enable, and upgrade modules for a platform via `platform backend`
+* Dynamically apply CLI devDependency version for new app and workspace, STCLI-109
 * Use correct relative path for package.json in `workspace` command, fixes STCLI-121
 
 ## [1.6.0](https://github.com/folio-org/stripes-cli/tree/v1.6.0) (2018-10-19)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
   * `mod remove` now supports multiple descriptor ids
   * Enable/disable and optionally deploy modules via `mod install`
   * Deploy, enable, and upgrade modules for a platform via `platform backend`
-
+* Use correct relative path for package.json in `workspace` command, fixes STCLI-121
 
 ## [1.6.0](https://github.com/folio-org/stripes-cli/tree/v1.6.0) (2018-10-19)
 

--- a/lib/environment/development.js
+++ b/lib/environment/development.js
@@ -8,7 +8,7 @@ const yarn = require('../yarn');
 const { allModules, uiModules, platforms, toFolioName } = require('./inventory');
 const AliasService = require('../platform/alias-service');
 const logger = require('../cli/logger')();
-const { version: currentCLIVersion } = require('../package.json');
+const { version: currentCLIVersion } = require('../../package.json');
 
 // Compare a list of module names against those known to be valid
 // Also automatically selects all modules, when "all" is provided


### PR DESCRIPTION
This uses the correct relative path for loading the CLI's own package.json in the `workspace` command.