### PR TITLE
STCLI-98: add sample API request to ui-app template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Dynamically apply CLI devDependency version for new app and workspace, STCLI-109
 * Use correct relative path for package.json in `workspace` command, fixes STCLI-121
 * Support using `mod install` simulate output as input for subsequent calls to command, STCLI-116
+*  Add sample API request to ui-app template
 
 
 ## [1.6.0](https://github.com/folio-org/stripes-cli/tree/v1.6.0) (2018-10-19)

--- a/resources/ui-app/src/index.js
+++ b/resources/ui-app/src/index.js
@@ -15,6 +15,11 @@ class <%= componentName %> extends React.Component {
   static propTypes = {
     match: PropTypes.object.isRequired,
     showSettings: PropTypes.bool,
+  };
+
+  constructor(props) {
+    super(props);
+    this.connectedExamplePage = props.stripes.connect(ExamplePage);
   }
 
   render() {
@@ -23,8 +28,16 @@ class <%= componentName %> extends React.Component {
     }
     return (
       <Switch>
-        <Route path={`${this.props.match.path}`} exact component={Application} />
-        <Route path={`${this.props.match.path}/examples`} exact component={ExamplePage} />
+        <Route
+          path={`${this.props.match.path}`}
+          exact
+          component={Application}
+        />
+        <Route
+          path={`${this.props.match.path}/examples`}
+          exact
+          component={this.connectedExamplePage}
+        />
       </Switch>
     );
   }

--- a/resources/ui-app/src/index.js
+++ b/resources/ui-app/src/index.js
@@ -19,22 +19,30 @@ class <%= componentName %> extends React.Component {
 
   constructor(props) {
     super(props);
+
     this.connectedExamplePage = props.stripes.connect(ExamplePage);
   }
 
   render() {
-    if (this.props.showSettings) {
+    const {
+      showSettings,
+      match: {
+        path
+      }
+    } = this.props;
+
+    if (showSettings) {
       return <Settings {...this.props} />;
     }
     return (
       <Switch>
         <Route
-          path={`${this.props.match.path}`}
+          path={path}
           exact
           component={Application}
         />
         <Route
-          path={`${this.props.match.path}/examples`}
+          path={`${path}/examples`}
           exact
           component={this.connectedExamplePage}
         />

--- a/resources/ui-app/src/routes/example-page.js
+++ b/resources/ui-app/src/routes/example-page.js
@@ -1,7 +1,9 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import Link from 'react-router-dom/Link';
+import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import { FormattedMessage } from 'react-intl';
+
 import {
   Button,
   Headline,
@@ -43,6 +45,7 @@ export default class ExamplePage extends React.Component {
 
   constructor(props) {
     super(props);
+
     this.toggleModal = this.toggleModal.bind(this);
     this.buttonClick = this.buttonClick.bind(this);
     this.onClose = this.onClose.bind(this);
@@ -89,15 +92,13 @@ export default class ExamplePage extends React.Component {
     } = this.getHealthSummary();
 
     return (
-      <Fragment>
-        <b>{healthyInstances}</b>
-        &nbsp;
-        <FormattedMessage id="<%= uiAppName %>.example-page.instances-healthy" />
-        ,&nbsp;
-        <b>{notHealthyInstances}</b>
-        &nbsp;
-        <FormattedMessage id="<%= uiAppName %>.example-page.instances-instances-not-healthy" />
-      </Fragment>
+      <SafeHTMLMessage
+        values={{
+          healthyInstances,
+          notHealthyInstances
+        }}
+        id="<%= uiAppName %>.example-page.health-summary"
+      />
     );
   }
 

--- a/resources/ui-app/src/routes/example-page.js
+++ b/resources/ui-app/src/routes/example-page.js
@@ -1,12 +1,15 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import Link from 'react-router-dom/Link';
+import { FormattedMessage } from 'react-intl';
 import {
   Button,
   Headline,
   Pane,
-  Paneset
+  Paneset,
+  Icon,
 } from '@folio/stripes-components';
+
 import GreetingModal from '../components/greeting-modal';
 
 /*
@@ -18,7 +21,25 @@ import GreetingModal from '../components/greeting-modal';
 export default class ExamplePage extends React.Component {
   static propTypes = {
     match: PropTypes.object.isRequired,
+    resources: PropTypes.shape({
+      health: PropTypes.shape({
+        hasLoaded: PropTypes.bool.isRequired,
+        records: PropTypes.arrayOf(PropTypes.shape({
+          healthMessage: PropTypes.string.isRequired,
+          healthStatus: PropTypes.bool.isRequired,
+          instId: PropTypes.string.isRequired,
+          srvcId: PropTypes.string.isRequired
+        })).isRequired
+      })
+    }).isRequired
   }
+
+  static manifest = Object.freeze({
+    health: {
+      type: 'okapi',
+      path: '_/discovery/health',
+    }
+  });
 
   constructor(props) {
     super(props);
@@ -40,7 +61,50 @@ export default class ExamplePage extends React.Component {
     this.toggleModal(true);
   }
 
+  getHealthSummary() {
+    const {
+      records: healthData
+    } = this.props.resources.health;
+
+    const defaultlHealthSummary = {
+      healthyInstances: 0,
+      notHealthyInstances: 0
+    };
+
+    return healthData.reduce((healthSummary, { healthStatus }) => {
+      if (healthStatus) {
+        healthSummary.healthyInstances++;
+      } else {
+        healthSummary.notHealthyInstances++;
+      }
+
+      return healthSummary;
+    }, defaultlHealthSummary);
+  }
+
+  renderHealthSummary() {
+    const {
+      healthyInstances,
+      notHealthyInstances,
+    } = this.getHealthSummary();
+
+    return (
+      <Fragment>
+        <b>{healthyInstances}</b>
+        &nbsp;
+        <FormattedMessage id="<%= uiAppName %>.example-page.instances-healthy" />
+        ,&nbsp;
+        <b>{notHealthyInstances}</b>
+        &nbsp;
+        <FormattedMessage id="<%= uiAppName %>.example-page.instances-instances-not-healthy" />
+      </Fragment>
+    );
+  }
+
   render() {
+    const { health } = this.props.resources;
+    const healthResourceAvaliable = health && health.hasLoaded;
+
     return (
       <Paneset static>
         <Pane defaultWidth="20%" paneTitle="Examples">
@@ -57,6 +121,17 @@ export default class ExamplePage extends React.Component {
             <Button onClick={this.buttonClick}>Click me</Button>
           </div>
           <GreetingModal onClose={this.onClose} open={this.state.showModal} />
+          <hr />
+          <Headline
+            size="small"
+            margin="medium"
+          >
+            <FormattedMessage id="<%= uiAppName %>.example-page.sample-request" />
+          </Headline>
+          {healthResourceAvaliable
+            ? this.renderHealthSummary()
+            : <Icon icon="spinner-ellipsis" />
+          }
           <hr />
           <Headline size="small" margin="medium">More...</Headline>
           Please refer to the

--- a/resources/ui-app/src/routes/example-page.js
+++ b/resources/ui-app/src/routes/example-page.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Link from 'react-router-dom/Link';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import { FormattedMessage } from 'react-intl';
 
 import {
@@ -92,10 +91,10 @@ export default class ExamplePage extends React.Component {
     } = this.getHealthSummary();
 
     return (
-      <SafeHTMLMessage
+      <FormattedMessage
         values={{
-          healthyInstances,
-          notHealthyInstances
+          healthyInstances: <b>{healthyInstances}</b>,
+          notHealthyInstances: <b>{notHealthyInstances}</b>
         }}
         id="<%= uiAppName %>.example-page.health-summary"
       />

--- a/resources/ui-app/test/bigtest/network/config.js
+++ b/resources/ui-app/test/bigtest/network/config.js
@@ -1,4 +1,42 @@
 // typical mirage config export
 // http://www.ember-cli-mirage.com/docs/v0.4.x/configuration/
 export default function config() {
+  this.get('_/discovery/health', () => ([
+    {
+      instId: '7fdb35df-eba1-403e-8e7a-39bf7b38871f',
+      srvcId: 'mod-inventory-storage-13.1.0-SNAPSHOT.184',
+      healthMessage: 'OK',
+      healthStatus: true
+    },
+    {
+      instId: '7fdb35df-eba1-403e-8e7a-39bf7b38872f',
+      srvcId: 'mod-inventory-storage-13.1.0-SNAPSHOT.184',
+      healthMessage: 'OK',
+      healthStatus: true
+    },
+    {
+      instId: '7fdb35df-eba1-403e-8e7a-39bf7b38873f',
+      srvcId: 'mod-inventory-storage-13.1.0-SNAPSHOT.184',
+      healthMessage: 'Fail',
+      healthStatus: false
+    },
+    {
+      instId: '7fdb35df-eba1-403e-8e7a-39bf7b38874f',
+      srvcId: 'mod-inventory-storage-13.1.0-SNAPSHOT.184',
+      healthMessage: 'OK',
+      healthStatus: true
+    },
+    {
+      instId: '7fdb35df-eba1-403e-8e7a-39bf7b38875f',
+      srvcId: 'mod-inventory-storage-13.1.0-SNAPSHOT.184',
+      healthMessage: 'OK',
+      healthStatus: true
+    },
+    {
+      instId: '7fdb35df-eba1-403e-8e7a-39bf7b38876f',
+      srvcId: 'mod-inventory-storage-13.1.0-SNAPSHOT.184',
+      healthMessage: 'Fail',
+      healthStatus: false
+    }
+  ]));
 }

--- a/resources/ui-app/translations/en.json
+++ b/resources/ui-app/translations/en.json
@@ -8,5 +8,5 @@
   "settings.some-feature.message": "These are your settings for some app feature.",
 
   "example-page.sample-request": "Sample API request",
-  "example-page.health-summary": "<b>{healthyInstances}</b> instances healthy, <b>{notHealthyInstances}</b> instances not healthy"
+  "example-page.health-summary": "{healthyInstances} instances healthy, {notHealthyInstances} instances not healthy"
 }

--- a/resources/ui-app/translations/en.json
+++ b/resources/ui-app/translations/en.json
@@ -8,6 +8,5 @@
   "settings.some-feature.message": "These are your settings for some app feature.",
 
   "example-page.sample-request": "Sample API request",
-  "example-page.instances-healthy": "instances healthy",
-  "example-page.instances-instances-not-healthy": "instances not healthy"
+  "example-page.health-summary": "<b>{healthyInstances}</b> instances healthy, <b>{notHealthyInstances}</b> instances not healthy"
 }

--- a/resources/ui-app/translations/en.json
+++ b/resources/ui-app/translations/en.json
@@ -5,5 +5,9 @@
   "settings.general": "General",
   "settings.general.message": "These are your general app settings.",
   "settings.some-feature": "Some Feature",
-  "settings.some-feature.message": "These are your settings for some app feature."
+  "settings.some-feature.message": "These are your settings for some app feature.",
+
+  "example-page.sample-request": "Sample API request",
+  "example-page.instances-healthy": "instances healthy",
+  "example-page.instances-instances-not-healthy": "instances not healthy"
 }


### PR DESCRIPTION
## Purpose
According to [STCLI-98](https://issues.folio.org/browse/STCLI-98), a working demonstration of how to make Okapi API requests should be added to ui-app template.

## Approach
`ExamplePage` component now has `manifest` static property, which includes  `_/discovery/health` endpoint used for requesting data from the back-end. The obtained data is processed by the component methods and displayed. Appropriate mirage mock is added

## Screenshots
![screen shot 2018-11-29 at 1 44 13 pm](https://user-images.githubusercontent.com/43514877/49219745-e3806f80-f3dc-11e8-8c5b-7fc5083e38ae.png)
