### PR TITLE
STCLI-123 use caret version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * New `mod perms` command to list permission for one or more modules, STCLI-115
 * Support permission assignment via `platform backend` command, STCLI-115
 * Rename `perm view` to `perm list` for consistency
+* Use caret version for CLI in workspace template, fixes STCLI-123
 
 
 ## [1.7.0](https://github.com/folio-org/stripes-cli/tree/v1.7.0) (2018-11-29)

--- a/resources/workspace/package.json
+++ b/resources/workspace/package.json
@@ -4,7 +4,7 @@
       "*"
   ],
   "devDependencies": {
-    "@folio/stripes-cli": "<%= cliVersion %>"
+    "@folio/stripes-cli": "^<%= cliVersion %>"
   },
   "dependencies": {
   }


### PR DESCRIPTION
Specifying an exact version of the CLI in the workspace template prevents Yarn from resolving that dependency when targeting `npm-folioci`.  This is because the `npm-folioci` registry uses inflated patch numbers and therefore does not offer an exact `1.7.0` version, for example.  By re-applying the caret `^` version range lost in a prior commit, we restore the ability to use the `stripes workspace` command while targeting `npm-folioci`.