### PR TITLE
Remove folio-testing-platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Support permission assignment via `platform backend` command, STCLI-115
 * Rename `perm view` to `perm list` for consistency
 * Use caret version for CLI in workspace template, fixes STCLI-123
+* Remove deprecated `folio-testing-platform` from selection during `workspace` command, FOLIO-1370
 
 
 ## [1.7.0](https://github.com/folio-org/stripes-cli/tree/v1.7.0) (2018-11-29)

--- a/lib/environment/inventory.js
+++ b/lib/environment/inventory.js
@@ -42,7 +42,6 @@ const stripesModules = [
 // They are not aliased or added to stripes.config.js
 const platforms = [
   'stripes-sample-platform',
-  'folio-testing-platform',
   'platform-core',
   'platform-complete',
   'platform-erm',


### PR DESCRIPTION
folio-testing-platform has been deprecated in favor of using the platform-complete snapshot branch.  The platform reflects a pre-stripes-framework state and therefore could cause issues if used as-is.  Also fixes FOLIO-1370