### PR TITLE
Upgrade yargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Rename `perm view` to `perm list` for consistency
 * Use caret version for CLI in workspace template, fixes STCLI-123
 * Remove deprecated `folio-testing-platform` from selection during `workspace` command, FOLIO-1370
+* Upgrade to Yargs 12.x
 
 
 ## [1.7.0](https://github.com/folio-org/stripes-cli/tree/v1.7.0) (2018-11-29)

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -42,6 +42,7 @@ This following command documentation is largely generated from the CLI's own bui
     * [`perm assign` command](#perm-assign-command)
     * [`perm unassign` command](#perm-unassign-command)
     * [`perm list` command](#perm-list-command)
+* [`completion` command](#completion-command)
 
 
 ## Common options
@@ -1126,4 +1127,13 @@ Examples:
 List permissions for user diku_admin:
 ```
 stripes perm list --user diku_admin
+```
+
+## `completion` command
+
+Generate a bash completion script.  Follow instructions included with the script for adding it to your bash profile.
+
+Usage:
+```
+stripes completion
 ```

--- a/lib/stripes-cli.js
+++ b/lib/stripes-cli.js
@@ -43,6 +43,7 @@ try {
     .example('$0 <command> --help', 'View examples and options for a command')
     .demandCommand()
     .env('STRIPES')
+    .scriptName('stripes')
     .help()
     .showHelpOnFail(false)
     .wrap(yargs.terminalWidth())

--- a/lib/stripes-cli.js
+++ b/lib/stripes-cli.js
@@ -38,6 +38,7 @@ try {
       type: 'boolean',
       default: true,
     })
+    .completion()
     .recommendCommands()
     .example('$0 <command> --help', 'View examples and options for a command')
     .demandCommand()

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "update-notifier": "^2.3.0",
     "webpack": "^4.10.2",
     "webpack-bundle-analyzer": "^3.0.1",
-    "yargs": "^10.0.3"
+    "yargs": "^12.0.5"
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^3.2.1",


### PR DESCRIPTION
This upgrades Yargs to 12.x offering new features and fixes.  For example, the ability to use `.completion()` with `.recommendCommands()` has been fixed (previously removed in https://github.com/folio-org/stripes-cli/commit/d2ebf2e2493f8e5a69c2db4c8798669c44f2ba41) and support for middleware added (referenced in STCLI-99).