### PR TITLE
STCLI-83 remove "--modules all"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Use caret version for CLI in workspace template, fixes STCLI-123
 * Remove deprecated `folio-testing-platform` from selection during `workspace` command, FOLIO-1370
 * Upgrade to Yargs 12.x
+* Remove "--modules all" option, fixes STCLI-83
 
 
 ## [1.7.0](https://github.com/folio-org/stripes-cli/tree/v1.7.0) (2018-11-29)

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -441,10 +441,6 @@ Create and select ui-users and stripes-core:
 ```
 stripes workspace --modules ui-users stripes-core
 ```
-Create and select all available modules:
-```
-stripes workspace --modules all
-```
 Create without installing dependencies:
 ```
 stripes workspace --no-install

--- a/lib/commands/workspace.js
+++ b/lib/commands/workspace.js
@@ -149,7 +149,6 @@ module.exports = {
       .example('$0 workspace', 'Create a "stripes" dir and prompt for modules')
       .example('$0 workspace --dir temp', 'Create an "temp" dir and prompt for modules')
       .example('$0 workspace --modules ui-users stripes-core', 'Create and select ui-users and stripes-core')
-      .example('$0 workspace --modules all', 'Create and select all available modules')
       .example('$0 workspace --no-install', 'Create without installing dependencies');
     return yargs;
   },

--- a/lib/environment/development.js
+++ b/lib/environment/development.js
@@ -11,14 +11,8 @@ const logger = require('../cli/logger')();
 const { version: currentCLIVersion } = require('../../package.json');
 
 // Compare a list of module names against those known to be valid
-// Also automatically selects all modules, when "all" is provided
 function validateModules(theModules) {
-  let selectedModules;
-  if (theModules.find(mod => mod === 'all')) {
-    selectedModules = allModules;
-  } else {
-    selectedModules = theModules.filter(mod => allModules.includes(mod));
-  }
+  const selectedModules = theModules.filter(mod => allModules.includes(mod));
   return selectedModules;
 }
 


### PR DESCRIPTION
This option has been removed from the workspace command rather than fixed because a workspace containing all possible modules is discouraged. If necessary, the interactive input still supports selection of all.