### PR TITLE
STCLI-120

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Remove deprecated `folio-testing-platform` from selection during `workspace` command, FOLIO-1370
 * Upgrade to Yargs 12.x
 * Remove "--modules all" option, fixes STCLI-83
+* Add `provide` and `require` options to `mod list` command, STCLI-120
 
 
 ## [1.7.0](https://github.com/folio-org/stripes-cli/tree/v1.7.0) (2018-11-29)

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -852,16 +852,26 @@ Option | Description | Type | Notes
 ---|---|---|---
 `--okapi` | Specify an Okapi URL | string | (*)
 `--tenant` | Specify a tenant ID | string |
+`--provide` | limit to provided interface | string |
+`--require` | limit to required interface | string |
 
 Examples:
 
-List enabled module ids for tenant diku:
-```
-stripes mod list --tenant diku
-```
 List all available module ids in Okapi:
 ```
 stripes mod list
+```
+List module ids that provide "notes" interface:
+```
+stripes mod list --provide notes
+```
+List module ids that require "notes" interface:
+```
+stripes mod list --require notes
+```
+List enabled module ids for tenant diku:
+```
+stripes mod list --tenant diku
 ```
 List available module ids in Okapi (overriding any tenant set via config):
 ```

--- a/lib/commands/mod/list.js
+++ b/lib/commands/mod/list.js
@@ -10,9 +10,14 @@ function listModuleCommand(argv, context) {
   const okapi = new Okapi(argv.okapi, argv.tenant);
   const moduleService = new ModuleService(okapi, context);
 
+  const options = {
+    provide: argv.provide,
+    require: argv.require,
+  };
+
   const promise = argv.tenant
-    ? moduleService.listModulesForTenant(argv.tenant)
-    : moduleService.listModules();
+    ? moduleService.listModulesForTenant(argv.tenant, options)
+    : moduleService.listModules(options);
 
   return promise
     .then((response) => {
@@ -29,8 +34,20 @@ module.exports = {
   describe: 'List all module ids available in Okapi or enabled for a tenant',
   builder: (yargs) => {
     yargs
-      .example('$0 mod list --tenant diku', 'List enabled module ids for tenant diku')
+      .option('provide', {
+        describe: 'limit to provided interface',
+        type: 'string',
+        conflicts: ['require'],
+      })
+      .option('require', {
+        describe: 'limit to required interface',
+        type: 'string',
+        conflicts: ['provide'],
+      })
       .example('$0 mod list', 'List all available module ids in Okapi')
+      .example('$0 mod list --provide notes', 'List module ids that provide "notes" interface')
+      .example('$0 mod list --require notes', 'List module ids that require "notes" interface')
+      .example('$0 mod list --tenant diku', 'List enabled module ids for tenant diku')
       .example('$0 mod list --no-tenant', 'List available module ids in Okapi (overriding any tenant set via config)');
     return applyOptions(yargs, Object.assign({}, okapiRequired, tenantOption));
   },

--- a/lib/commands/mod/view.js
+++ b/lib/commands/mod/view.js
@@ -19,7 +19,7 @@ function viewModuleCommand(argv, context) {
     return Promise.reject();
   }
 
-  return moduleService.viewModuleDescriptors(descriptorIds, argv.tenant)
+  return moduleService.viewModuleDescriptors(descriptorIds)
     .then((responses) => {
       console.log(JSON.stringify(responses, null, 2));
     });

--- a/lib/okapi/module-service.js
+++ b/lib/okapi/module-service.js
@@ -122,14 +122,32 @@ module.exports = class ModuleService {
       .reduce((promiseChain, currentFunction) => promiseChain.then(currentFunction), Promise.resolve());
   }
 
-  listModulesForTenant(tenant) {
-    return this.okapi.proxy.getModulesForTenant(tenant)
+  async listModulesForTenant(tenant, options) {
+    const tenantPromise = this.okapi.proxy.getModulesForTenant(tenant)
       .then(response => response.json())
       .then(data => data.map(mod => mod.id));
+
+    // Optionally filter the tenant list with a call to listModules
+    if (options && (options.require || options.provide)) {
+      const filter = await this.listModules(options);
+      const tenantModules = await tenantPromise;
+      return Promise.resolve(tenantModules.filter(id => filter.includes(id)));
+    }
+
+    // Nothing to filter
+    return tenantPromise;
   }
 
-  listModules() {
-    return this.okapi.proxy.getModules()
+  listModules(options) {
+    let promise;
+    if (options && options.require) {
+      promise = this.okapi.proxy.getModulesThatRequireInterface(options.require);
+    } else if (options && options.provide) {
+      promise = this.okapi.proxy.getModulesThatProvideInterface(options.provide);
+    } else {
+      promise = this.okapi.proxy.getModules();
+    }
+    return promise
       .then(response => response.json())
       .then(data => data.map(mod => mod.id));
   }

--- a/lib/okapi/okapi-repository.js
+++ b/lib/okapi/okapi-repository.js
@@ -40,6 +40,14 @@ function getModules() {
   return okapiClient.get('/_/proxy/modules', noTenantNoToken);
 }
 
+function getModulesThatRequireInterface(moduleInterface) {
+  return okapiClient.get(`/_/proxy/modules?require=${moduleInterface}`, noTenantNoToken);
+}
+
+function getModulesThatProvideInterface(moduleInterface) {
+  return okapiClient.get(`/_/proxy/modules?provide=${moduleInterface}`, noTenantNoToken);
+}
+
 function installModulesForTenant(modulePayload, tenant, options) {
   return okapiClient.post(`/_/proxy/tenants/${tenant}/install?simulate=${options.simulate}&deploy=${options.deploy}&preRelease=${options.preRelease}`, modulePayload, noTenantNoToken);
 }
@@ -79,6 +87,8 @@ const okapiRoutes = {
     getModulesForTenant,
     installModulesForTenant,
     pullModuleDescriptorsFromRemote,
+    getModulesThatRequireInterface,
+    getModulesThatProvideInterface,
   },
   perms: {
     assignPermissionToUser,


### PR DESCRIPTION
This wires up `provide` and `require` query string parameters recently added to `/_/proxy/modules` in Okapi 2.21.  Both are now available as options in CLI's `mod list` command.