### PR TITLE
STCLI-124 guard against unset karma options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Upgrade to Yargs 12.x
 * Remove "--modules all" option, fixes STCLI-83
 * Add `provide` and `require` options to `mod list` command, STCLI-120
+* Guard against unset karma options, fixes STCLI-124
 
 
 ## [1.7.0](https://github.com/folio-org/stripes-cli/tree/v1.7.0) (2018-11-29)

--- a/lib/test/karma-service.js
+++ b/lib/test/karma-service.js
@@ -98,7 +98,7 @@ module.exports = class KarmaService {
       Object.assign(karmaConfig, karmaOptions);
     }
 
-    if (karmaOptions.coverage) {
+    if (karmaOptions && karmaOptions.coverage) {
       logger.log('Enabling coverage');
       karmaConfig.reporters.push('coverage-istanbul');
       karmaConfig.plugins.push('karma-coverage-istanbul-reporter');


### PR DESCRIPTION
This issue was likely caused by the upgrade to Yargs which introduced a difference in handling of unset command-line options.