### PR TITLE
Add support for stripes-core 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Remove "--modules all" option, fixes STCLI-83
 * Add `provide` and `require` options to `mod list` command, STCLI-120
 * Guard against unset karma options, fixes STCLI-124
+* Add support for `stripes-core` `v3.x`
 
 
 ## [1.7.0](https://github.com/folio-org/stripes-cli/tree/v1.7.0) (2018-11-29)

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint-templates": "eslint ./resources --no-ignore"
   },
   "dependencies": {
-    "@folio/stripes-core": "^2.16.0",
+    "@folio/stripes-core": "^2.17.1 || ^3.0.0",
     "@folio/stripes-testing": "^1.0.0",
     "babel-plugin-istanbul": "^4.1.6",
     "configstore": "^3.1.1",


### PR DESCRIPTION
There are no breaking changes related to the build/serve API exposed by stripes-core in version 3.x, therefore the CLI will continue to work with either major version.  This should ease transition for folks who happen to update the CLI independent of stripes-core or stripes framework.