### PR TITLE
STCLI-125 descriptor files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   * New isBackendModule context to identify back-end modules
   * Support back-end module context for `mod add/remove/enable/disable` commands
   * New `mod discover` command to register instances with Okapi
+* New mod descriptor `--output` option for writing module descriptors to a directory
 
 
 ## [1.8.0](https://github.com/folio-org/stripes-cli/tree/v1.8.0) (2019-01-16)

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -824,6 +824,7 @@ Option | Description | Type | Notes
 ---|---|---|---
 `--full` | Return full module descriptor JSON | boolean | default: false
 `--strict` | Include required interface dependencies | boolean | default: false
+`--output` | Directory to write descriptors to as JSON files | string |
 
 Examples:
 

--- a/lib/commands/mod/descriptor.js
+++ b/lib/commands/mod/descriptor.js
@@ -7,7 +7,10 @@ function moduleDescriptorCommand(argv, context) {
   const descriptorService = new DescriptorService(context, argv.configFile);
   const descriptors = descriptorService.getModuleDescriptorsFromContext(argv.strict);
 
-  if (argv.full) {
+  if (argv.output) {
+    DescriptorService.writeModuleDescriptorsToDirectory(descriptors, argv.output);
+    console.log(`${descriptors.length} module descriptors written to ${argv.output}`);
+  } else if (argv.full) {
     console.log(JSON.stringify(descriptors, null, 2));
   } else {
     descriptors.forEach(descriptor => console.log(descriptor.id));
@@ -32,6 +35,10 @@ module.exports = {
         describe: 'Include required interface dependencies',
         type: 'boolean',
         default: false,
+      })
+      .option('output', {
+        describe: 'Directory to write descriptors to as JSON files',
+        type: 'string',
       })
       .example('$0 mod descriptor', 'Display module descriptor id for current app')
       .example('$0 mod descriptor stripes.config.js', 'Display module descriptor ids for platform')

--- a/lib/okapi/descriptor-service.js
+++ b/lib/okapi/descriptor-service.js
@@ -88,4 +88,19 @@ module.exports = class DescriptorService {
     const idsToAdd = uniq(automaticallyAdded.concat(manuallyAdded || []));
     return moduleDescriptorIds.concat(idsToAdd);
   }
+
+  static writeModuleDescriptorsToDirectory(descriptors, outdir) {
+    if (!fs.existsSync(outdir)) {
+      fs.mkdirSync(outdir);
+    }
+
+    // Write descriptors to individual files
+    descriptors.forEach(descriptor => {
+      // Regex to find a name like "plugin-find-user" inside of an id like "folio_plugin-find-user-1.4.100038"
+      const nameMatch = descriptor.id.match(/folio_(.*)-/);
+      const filename = nameMatch ? nameMatch[1] : descriptor.id;
+      const formattedJson = JSON.stringify(descriptor, null, 2);
+      fs.writeFileSync(`${outdir}/${filename}.json`, `${formattedJson}\n`, { encoding: 'utf8' });
+    });
+  }
 };


### PR DESCRIPTION
This adds support for writing module descriptors to files.  Writing to files triggered by a new `--output` option on the existing `mod descriptor` command.  With this functionality, we will be able to retire the `build-module-descriptors.js` script currently duplicated within in each platform.
