### PR TITLE
Add missing quotes to example with array-typed option

### DIFF
--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -69,7 +69,7 @@ Notes:
 
 Example passing array values for `modules` and false for `install`:
 ```
-stripes workspace --modules ui-users stripes-core stripes-components --no-install
+stripes workspace --modules "ui-users stripes-core stripes-components" --no-install
 ```
 
 ### Standard input


### PR DESCRIPTION
I _think_ this must be right, according to the description that precedes it.