### PR TITLE
STCLI-114 follow-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Stripes CLI is a command line interface to facilitate the creation, development,
 * [User Guide](./doc/user-guide.md)
 * [List of Commands](./doc/commands.md)
 * [Developer Guide](./doc/dev-guide.md)
+* [Back-end Guide](./doc/backend-guide.md)
 * [Troubleshooting](./doc/troubleshooting.md)
 
 ## Installation

--- a/doc/backend-guide.md
+++ b/doc/backend-guide.md
@@ -3,30 +3,30 @@
 Stripes CLI offers many commands for interacting with Okapi to manage back-end modules for a tenant on a Vagrant VM.  This guide steps through the process of standing up a back-end to support a unique front-end platform.
 
 * [Prerequisites](#prerequisites)
-    * [1. Create a Vagrant box](#1-create-a-vagrant-box)
-    * [2. Install a front-end platform](#2-install-a-front-end-platform)
-    * [3. Configure the CLI (optional)](#3-configure-the-cli-optional)
+    * [Create a Vagrant box](#create-a-vagrant-box)
+    * [Install a front-end platform](#install-a-front-end-platform)
+    * [Configure the CLI (optional)](#configure-the-cli-optional)
 * [Set up back-end modules for your platform](#set-up-back-end-modules-for-your-platform)
-    * [1. Set up back-end in one command](#1-set-up-back-end-in-one-command)
+    * [Set up back-end in one command](#set-up-back-end-in-one-command)
     * [Useful variants](#useful-variants)
 * [Set up back-end modules for your platform (multi-step)](#set-up-back-end-modules-for-your-platform-multi-step)
-    * [1. Pull modules](#1-pull-modules)
-    * [2. Generate front-end module ids](#2-generate-front-end-module-ids)
-    * [3. Include additional dependencies](#3-include-additional-dependencies)
-    * [4. Perform a dry run](#4-perform-a-dry-run)
-    * [5. Perform the back-end deployment](#5-perform-the-back-end-deployment)
-    * [6. Post the front-end module descriptors](#6-post-the-front-end-module-descriptors)
-    * [7. Assign permissions to a user](#7-assign-permissions-to-a-user)
+    * [Pull modules](#pull-modules)
+    * [Generate front-end module ids](#generate-front-end-module-ids)
+    * [Include additional dependencies](#include-additional-dependencies)
+    * [Perform a dry run](#perform-a-dry-run)
+    * [Perform the back-end deployment](#perform-the-back-end-deployment)
+    * [Post the front-end module descriptors](#post-the-front-end-module-descriptors)
+    * [Assign permissions to a user](#assign-permissions-to-a-user)
 * [Connect a local back-end module to an existing platform](#connect-a-local-back-end-module-to-an-existing-platform)
-    * [1. Prerequisites](#1-prerequisites)
-    * [2. Post your backend module descriptor](#2-post-your-backend-module-descriptor)
-    * [3. Register your local running instance with Okapi](#3-register-your-local-running-instance-with-okapi)
-    * [4. Enable your module for the tenant](#4-enable-your-module-for-the-tenant)
+    * [Prerequisites](#prerequisites)
+    * [Post your backend module descriptor](#post-your-backend-module-descriptor)
+    * [Register your local running instance with Okapi](#register-your-local-running-instance-with-okapi)
+    * [Enable your module for the tenant](#enable-your-module-for-the-tenant)
 
 
 ## Prerequisites
 
-### 1. Create a Vagrant box
+### Create a Vagrant box
 
 This guide requires [folio/snapshot-backend-core](https://app.vagrantup.com/folio/boxes/snapshot-backend-core), [folio/snapshot-core](https://app.vagrantup.com/folio/boxes/snapshot-core), [folio/minimal](https://issues.folio.org/browse/FOLIO-1730), or equivalent Vagrant box.  The "core" VMs come pre-loaded with modules to run [platform-core](https://github.com/folio-org/platform-core) modules.
 
@@ -40,7 +40,7 @@ $ vagrant up
 See the Stripes development setup guide for information to [update an existing Vagrant box](https://github.com/folio-org/stripes/blob/master/doc/new-development-setup.md#update-your-vagrant-box).
 
 
-### 2. Install a front-end platform
+### Install a front-end platform
 
 Start by cloning your desired platform, such as [platform-erm](https://github.com/folio-org/platform-erm).
 
@@ -50,7 +50,7 @@ $ cd platform-erm
 $ yarn install
 ```
 
-### 3. Configure the CLI (optional)
+### Configure the CLI (optional)
 
 Optionally, create a `.stripesclirc` [configuration file](https://github.com/folio-org/stripes-cli/blob/master/doc/user-guide.md#configuration) to store an Okapi URL and tenant ID. Place your CLI configuration in your platform directory or above.
 
@@ -76,7 +76,7 @@ The CLI attempts to simplify the back-end setup process by automating many steps
 $ stripes mod add --strict
 ```
 
-### 1. Set up back-end in one command
+### Set up back-end in one command
 
 The following command, run from within your platform directory, will prepare and deploy modules and their dependencies for your tenant via Okapi's `/_/proxy/tenants/{tenant_id}/install` endpoint.
 
@@ -115,21 +115,21 @@ $ stripes platform backend stripes.config.js --include mod-x mod-y
 
 For more granular control or to better observe the intermediate operations above, the following individual commands can be performed to achieve the same result.
 
-### 1. Pull modules
+### Pull modules
 Your Vagrant box will only have module descriptors available for the modules that it came pre-built with.  The `mod pull` command will instruct Okapi to download the latest module descriptor ids from a remote registry.
 
 ```
 $ stripes mod pull --remote http://folio-registry.aws.indexdata.com
 ```
  
-### 2. Generate front-end module ids
+### Generate front-end module ids
 
 This will take the tenant config, `stripes.config.js` and convert the selected modules into module descriptor ids.  Additional front-end `stripes-*` modules will be included like `stripes-core`.
 ```
 $ stripes mod descriptor stripes.config.js > my-module-ids
 ```
 
-### 3. Include additional dependencies
+### Include additional dependencies
 
 While `stripes platform backend` offers some logic to dynamically append a few module ids that are not otherwise required by a front-end platform, the CLI doesn't currently offer a stand-alone command to do the same.  Manually add any module ids that you know you need, but are not pulled as a dependency of other modules.  Simply edit the prior output file to append the desired ids.
 
@@ -141,7 +141,7 @@ mod-y
 EOF
 ```
 
-### 4. Perform a dry run
+### Perform a dry run
 
 Using the `my-module-ids` file from the prior command as input, pipe the list to `stripes mod install` with the `--simulate` option set.  This will call Okapi to generate a list of the necessary dependencies and their actions, such as enabling or upgrading, needed.  Save this output to a file as it will be used in the next steps.
 
@@ -149,7 +149,7 @@ Using the `my-module-ids` file from the prior command as input, pipe the list to
 $ cat my-module-ids | stripes mod install --simulate > my-module-actions
 ```
 
-### 5. Perform the back-end deployment
+### Perform the back-end deployment
 
 Using the output from the `--simulate` dry run, filter the results for back-end modules.  For this you can pipe your output through the `stripes mod filter` command. Then pass the filtered results onto `stripes mod install` with the `--deploy` option.
 
@@ -158,7 +158,7 @@ $ cat my-module-actions | stripes mod filter --back | stripes mod install --depl
 ```
 
 
-### 6. Post the front-end module descriptors
+### Post the front-end module descriptors
 
 Using the same output from the dry run, this time filter the results for front-end modules only. Pass the results to `stripes mod install` (without `--deploy`) enable them for the tenant.
 
@@ -166,7 +166,7 @@ Using the same output from the dry run, this time filter the results for front-e
 $ cat my-module-actions | stripes mod filter --front | stripes mod install
 ```
 
-### 7. Assign permissions to a user
+### Assign permissions to a user
 
 In order to make use of the newly installed modules for development, assign module permissions to a user.  This can be done by chaining a few `stripes` commands together.  The following will gather permissions for all of the tenant's modules, and attempt to assign them to the user.
 
@@ -178,7 +178,7 @@ $ stripes mod list | stripes mod perms | stripes perm assign --user diku_admin
 
 The following describes how to incorporate a local development instance of a backend module with an existing Okapi using `stripes` CLI commands.
 
-### 1. Prerequisites
+### Prerequisites
 
 * Create and run the [folio/snapshot-core](#create-a-vagrant-box) vagrant box
 * Build and host your local back-end module following its instructions ([example](https://github.com/folio-org/raml-module-builder#get-started-with-a-sample-working-module)).
@@ -186,7 +186,7 @@ The following describes how to incorporate a local development instance of a bac
 Commands below assume `--okapi` and `--tenant` values have been set via [configuration](#configure-the-cli-optional).  Please include these options with your commands if not previously set.
 
 
-### 2. Post your backend module descriptor
+### Post your backend module descriptor
 
 From your back-end module's directory, post its module descriptor with the `mod add` command.  It is important to run this command after an install/build since the module descriptor found within the `/target` directory will be used. 
 
@@ -194,7 +194,7 @@ From your back-end module's directory, post its module descriptor with the `mod 
 $ stripes mod add
 ```
 
-### 3. Register your local running instance with Okapi
+### Register your local running instance with Okapi
 
 From the back-end module's directory, use the `mod discover` command register your locally running module instance. Provide the port where it is hosted locally.
 
@@ -205,7 +205,7 @@ $ stripes mod discover --port 8080
 Variations of this command can be useful. For example, to see existing instances, run the command with no options.  To clear out all existing instances, use the `--forget` option.  See [mod discover](./commands.md#mod-discover-command-work-in-progress) in the command reference for more information.
 
 
-### 4. Enable your module for the tenant
+### Enable your module for the tenant
 
 For the commands below, `mod descriptor` simply returns the module descriptor id so that we can pipe this into the `mod install` command.
 

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -17,7 +17,7 @@ This following command documentation is generated from the CLI's own built-in he
     * [`mod add` command](#mod-add-command)
     * [`mod descriptor` command](#mod-descriptor-command)
     * [`mod disable` command](#mod-disable-command)
-    * [`mod discover` command (work in progress)](#mod-discover-command-work-in-progress)
+    * [`mod discover` command](#mod-discover-command)
     * [`mod enable` command](#mod-enable-command)
     * [`mod filter` command](#mod-filter-command)
     * [`mod install` command](#mod-install-command)
@@ -245,7 +245,7 @@ Sub-commands:
 * [`stripes mod add`](#mod-add-command)
 * [`stripes mod descriptor`](#mod-descriptor-command)
 * [`stripes mod disable`](#mod-disable-command)
-* [`stripes mod discover`](#mod-discover-command-work-in-progress)
+* [`stripes mod discover`](#mod-discover-command)
 * [`stripes mod enable`](#mod-enable-command)
 * [`stripes mod filter`](#mod-filter-command)
 * [`stripes mod install`](#mod-install-command)
@@ -341,9 +341,9 @@ Disable module ids "one" and "two" for tenant diku with stdin:
 $ echo one two | stripes mod disable --tenant diku
 ```
 
-### `mod discover` command (work in progress)
+### `mod discover` command
 
-Manage instances for the current backend module with Okapi's _/discovery endpoint (work in progress)
+Manage instances for the current backend module with Okapi's _/discovery endpoint
 
 Usage:
 ```

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -354,6 +354,7 @@ Option | Description | Type | Notes
 ---|---|---|---
 `--forget` | Unregister instances | boolean |
 `--okapi` | Specify an Okapi URL | string | (*)
+`--port` | Register a locally hosted instance running on port number (for use with Okapi in a Vagrant box) | number |
 `--url` | Register instance running at URL | string |
 
 Examples:

--- a/lib/commands/mod/discover.js
+++ b/lib/commands/mod/discover.js
@@ -51,7 +51,7 @@ function discoverModuleCommand(argv, context) {
 
 module.exports = {
   command: 'discover',
-  describe: 'Manage instances for the current backend module with Okapi\'s _/discovery endpoint (work in progress)',
+  describe: 'Manage instances for the current backend module with Okapi\'s _/discovery endpoint',
   builder: (yargs) => {
     yargs
       .option('port', {

--- a/lib/commands/mod/discover.js
+++ b/lib/commands/mod/discover.js
@@ -23,6 +23,13 @@ function discoverModuleCommand(argv, context) {
           console.log(`No instances found for ${response.id}`);
         }
       });
+  } else if (argv.port) {
+    return discoveryService.addLocalInstanceForContextOnVagrantVM(argv.port)
+      .then((response) => {
+        if (response.success) {
+          console.log(`Module ${response.id} instance ${response.instId} registered with Okapi`);
+        }
+      });
   } else if (argv.url) {
     return discoveryService.addInstanceForContext(argv.url)
       .then((response) => {
@@ -47,15 +54,20 @@ module.exports = {
   describe: 'Manage instances for the current backend module with Okapi\'s _/discovery endpoint (work in progress)',
   builder: (yargs) => {
     yargs
+      .option('port', {
+        describe: 'Register a locally hosted instance running on port number (for use with Okapi in a Vagrant box)',
+        type: 'number',
+        conflicts: ['forget', 'url'],
+      })
       .option('url', {
         describe: 'Register instance running at URL',
         type: 'string',
-        conflicts: 'forget',
+        conflicts: ['forget', 'port'],
       })
       .option('forget', {
         describe: 'Unregister instances',
         type: 'boolean',
-        conflicts: 'url',
+        conflicts: ['url', 'port'],
       })
       .example('$0 mod discover', 'View current instances')
       .example('$0 mod discover --url', 'Register instance running at URL with Okapi')

--- a/lib/okapi/discovery-service.js
+++ b/lib/okapi/discovery-service.js
@@ -1,8 +1,6 @@
 const path = require('path');
 const fs = require('fs');
-const uuidv4 = require('uuid/v4');
 const { resolveIfOkapiSays } = require('../okapi/okapi-utils');
-
 
 module.exports = class DiscoveryService {
   constructor(okapiRepository, context) {
@@ -50,12 +48,24 @@ module.exports = class DiscoveryService {
       });
   }
 
-  addInstanceForContext(url) {
+  addLocalInstanceForContextOnVagrantVM(port) {
     const descriptor = this.getDeploymentDescriptor();
 
-    // TODO: Validate URL
+    // Services on the host system are accessible to the guest VM at 10.0.2.2 (standard Vagrant NAT networking setup)
+    descriptor.url = `http://10.0.2.2:${port}`;
+    descriptor.instId = `${this.context.moduleName}-on-host-added-by-cli`;
+
+    // Not used
+    delete descriptor.nodeId;
+    delete descriptor.descriptor;
+
+    return this.addInstance(descriptor);
+  }
+
+  addInstanceForContext(url) {
+    const descriptor = this.getDeploymentDescriptor();
     descriptor.url = url;
-    descriptor.instId = uuidv4();
+    descriptor.instId = `${this.context.moduleName}-at-url-added-by-cli`;
 
     // Not used
     delete descriptor.nodeId;

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "simple-git": "^1.89.0",
     "supports-color": "^4.5.0",
     "update-notifier": "^2.3.0",
-    "uuid": "^3.3.2",
     "webpack": "^4.10.2",
     "webpack-bundle-analyzer": "^3.0.1",
     "yargs": "^12.0.5"

--- a/test/okapi/discovery-service.spec.js
+++ b/test/okapi/discovery-service.spec.js
@@ -122,6 +122,37 @@ describe('The discovery-service', function () {
     });
   });
 
+  describe('addLocalInstanceForContextOnVagrantVM method', function () {
+    beforeEach(function () {
+      this.sut = new DiscoveryService(okapiStub, contextStub);
+      this.sandbox.stub(fs, 'existsSync').returns(true);
+      this.sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(deploymentDescriptorStub));
+      this.sandbox.spy(okapiStub.discovery, 'addInstance');
+    });
+
+    it('Assigns port to "10.0.2.2" and instance id', function (done) {
+      this.sut.addLocalInstanceForContextOnVagrantVM(8080)
+        .then(() => {
+          expect(okapiStub.discovery.addInstance).to.have.been.calledOnce;
+          const call = okapiStub.discovery.addInstance.getCall(0);
+          expect(call.args[0]).to.be.an('object').to.have.keys('instId', 'url', 'srvcId');
+          expect(call.args[0].instId).to.be.a('string');
+          expect(call.args[0].url).to.equal('http://10.0.2.2:8080');
+          done();
+        });
+    });
+
+    it('Omits nodeId and descriptor', function (done) {
+      this.sut.addLocalInstanceForContextOnVagrantVM(8080)
+        .then(() => {
+          expect(okapiStub.discovery.addInstance).to.have.been.calledOnce;
+          const call = okapiStub.discovery.addInstance.getCall(0);
+          expect(call.args[0]).to.be.an('object').not.to.have.keys('nodeId', 'descriptor');
+          done();
+        });
+    });
+  });
+
   describe('addInstanceForContext method', function () {
     beforeEach(function () {
       this.sut = new DiscoveryService(okapiStub, contextStub);


### PR DESCRIPTION
This wraps up STCLI-114 with updated documentation referencing the new `snapshot-backend-core` VMs. New support has been added to`mod discover` to use the VM's default NAT gateway [described here](https://github.com/folio-org/folio-ansible/blob/7d2137478ce92cec56ab33e35b89ea403548b6ee/doc/index.md#running-backend-modules-on-your-host-system) when registering a locally hosted back-end module with the VM.