### PR TITLE
STCLI-96 --no-minify

### DIFF
--- a/doc/commands.md
+++ b/doc/commands.md
@@ -214,6 +214,7 @@ Option | Description | Type | Notes
 `--languages` | Languages to include in tenant build | array |
 `--lint` | Show eslint warnings with build | boolean |
 `--maxChunks` | Limit the number of Webpack chunks in build output | number |
+`--minify` | Minify the bundle output | boolean | default: true
 `--okapi` | Specify an Okapi URL | string |
 `--output` | Directory to place build output | string |
 `--prod` | Use production build settings | boolean |
@@ -223,13 +224,17 @@ Option | Description | Type | Notes
 
 Examples:
 
-Platform context build:
+Build a platform (from platform directory):
 ```
-$ stripes build stripes.config.js dir
+$ stripes build stripes.config.js ./output-dir
 ```
-App context build using virtual platform:
+Build a platform without minification of the bundle:
 ```
-$ stripes build --output=dir
+$ stripes build stripes.config.js ./output-dir --no-minify
+```
+Build a single ui-module (from ui-module directory):
+```
+$ stripes build --output ./output-dir
 ```
 
 ## `mod` command

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -83,8 +83,14 @@ module.exports = {
         describe: 'Run the Webpack Bundle Analyzer after build (launches in browser)',
         type: 'boolean',
       })
-      .example('$0 build stripes.config.js dir', 'Platform context build')
-      .example('$0 build --output=dir', 'App context build using virtual platform');
+      .option('minify', {
+        describe: 'Minify the bundle output',
+        type: 'boolean',
+        default: true,
+      })
+      .example('$0 build stripes.config.js ./output-dir', 'Build a platform (from platform directory)')
+      .example('$0 build stripes.config.js ./output-dir --no-minify', 'Build a platform without minification of the bundle')
+      .example('$0 build --output ./output-dir', 'Build a single ui-module (from ui-module directory)');
     return applyOptions(yargs, Object.assign({}, okapiOptions, stripesConfigOptions, buildOptions));
   },
   handler: mainHandler(buildCommand),


### PR DESCRIPTION
This includes `--no-minify` in CLI documentation. This is a feature that has been in place for quite some time and works because the CLI will pass the `--no-minify` option to stripes-core (where it has been implemented).  However, the option's existence was never surfaced in the CLI help docs.