### PR TITLE
STCLI-78 replace context.type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   * New `mod discover` command to register instances with Okapi
 * New mod descriptor `--output` option for writing module descriptors to a directory, STCLI-125
 * Automate generation of CLI command reference, STCLI-128
+* Refactor usage of context.type, STCLI-78
 
 
 ## [1.8.0](https://github.com/folio-org/stripes-cli/tree/v1.8.0) (2019-01-16)

--- a/lib/cli/context.js
+++ b/lib/cli/context.js
@@ -22,7 +22,7 @@ function isGlobalYarn() {
 }
 
 function isUiModule(type) {
-  return ['app', 'settings'].some(val => val === type);
+  return ['app', 'settings', 'plugin'].some(val => val === type);
 }
 
 function isStripesModule(name) {
@@ -52,10 +52,12 @@ function getContext(dir) {
     isLocalCoreAvailable: false,
     cwd: workingDir,
     cliRoot,
+    isEmpty: false,
     isUiModule: false,
     isStripesModule: false,
     isPlatform: false,
     isBackendModule: false,
+    isWorkspace: false,
   };
 
   let cwdPackageJson;
@@ -80,12 +82,14 @@ function getContext(dir) {
   // No package.json so assume this is an empty project
   if (!cwdPackageJson && !cwdPomXml) {
     ctx.type = 'empty';
+    ctx.isEmpty = true;
     return ctx;
   }
 
   // Operating within in the Stripes CLI
   if (ctx.cwd === cliRoot) {
     ctx.type = 'cli';
+    ctx.isCli = true;
     return ctx;
   }
 
@@ -101,6 +105,7 @@ function getContext(dir) {
   // Package.json contains workspace with a stripes reference, assume this is a stripes workspace
   if (cwdPackageJson.workspaces) {
     ctx.type = 'workspace';
+    ctx.isWorkspace = true;
     return ctx;
   }
 

--- a/lib/commands/app/bigtest.js
+++ b/lib/commands/app/bigtest.js
@@ -5,7 +5,7 @@ const bigtest = importLazy('../../test/setup-bigtest');
 const yarn = importLazy('../../yarn');
 
 function setupBigTestCommand(argv, context) {
-  if (context.type !== 'app') {
+  if (!context.isUiModule) {
     console.log('"app bigtest" only works in the APP context');
     return Promise.resolve();
   }

--- a/lib/commands/app/create.js
+++ b/lib/commands/app/create.js
@@ -11,10 +11,10 @@ const path = importLazy('path');
 
 function createAppCommand(argv, context) {
   let appData;
-  const isWorkspace = context.type === 'workspace';
+  const isWorkspace = context.isWorkspace;
 
   // TODO: Verify destination folder
-  if (context.type !== 'empty' && !isWorkspace) {
+  if (!context.isEmpty && !isWorkspace) {
     console.log('Existing package.json found. Nothing created.');
     return Promise.resolve();
   }

--- a/lib/commands/app/perms.js
+++ b/lib/commands/app/perms.js
@@ -4,7 +4,7 @@ const path = importLazy('path');
 const { mainHandler } = importLazy('../../cli/main-handler');
 
 function appPermsCommand(argv, context) {
-  if (context.type !== 'app') {
+  if (!context.isUiModule) {
     console.log('"app perms" only works in the APP context');
     return;
   }

--- a/lib/commands/perm/create.js
+++ b/lib/commands/perm/create.js
@@ -12,8 +12,8 @@ const assignPermCommand = importLazy('../perm/assign');
 
 function createPermCommand(argv, context) {
   // check for app context, then load package.json
-  if (context.type !== 'app') {
-    return 'Only APP modules are supported by perm commands.';
+  if (!context.isUiModule) {
+    return console.log('This command must be run from a ui-module');
   }
 
   const okapi = new Okapi(argv.okapi, argv.tenant);

--- a/lib/commands/platform/clean.js
+++ b/lib/commands/platform/clean.js
@@ -26,12 +26,12 @@ function cleanNodeModules(dir) {
 }
 
 function cleanCommand(argv, context) {
-  if (context.type !== 'workspace' && context.type !== 'platform') {
+  if (!context.isWorkspace && !context.isPlatform) {
     console.log('This command must be run from a platform or workspace context');
     return Promise.resolve();
   }
 
-  const dev = new DevelopmentEnvironment(context.cwd, context.type === 'workspace');
+  const dev = new DevelopmentEnvironment(context.cwd, context.isWorkspace);
   dev.loadExistingModules();
   const moduleDirs = dev.getModulePaths();
 

--- a/lib/commands/platform/install.js
+++ b/lib/commands/platform/install.js
@@ -5,12 +5,12 @@ const DevelopmentEnvironment = importLazy('../../environment/development');
 
 
 function installCommand(argv, context) {
-  if (context.type !== 'workspace' && context.type !== 'platform') {
+  if (!context.isWorkspace && !context.isPlatform) {
     console.log('This command must be run from a platform or workspace context');
     return Promise.resolve();
   }
 
-  const dev = new DevelopmentEnvironment(context.cwd, context.type === 'workspace');
+  const dev = new DevelopmentEnvironment(context.cwd, context.isWorkspace);
   dev.loadExistingModules();
 
   return dev.installDependencies()

--- a/lib/commands/platform/pull.js
+++ b/lib/commands/platform/pull.js
@@ -64,17 +64,17 @@ function pullRepository(dir) {
 
 
 function pullCommand(argv, context) {
-  if (context.type !== 'workspace' && context.type !== 'platform') {
+  if (!context.isWorkspace && !context.isPlatform) {
     console.log('This command must be run from a platform or workspace context');
     return Promise.resolve();
   }
 
-  const dev = new DevelopmentEnvironment(context.cwd, context.type === 'workspace');
+  const dev = new DevelopmentEnvironment(context.cwd, context.isWorkspace);
   dev.loadExistingModules();
   const moduleDirs = dev.getModulePaths();
 
   // While the workspace directory is needed for cleaning and installing, it is not used for pulling so omit it
-  if (context.type === 'workspace') {
+  if (context.isWorkspace) {
     const workspaceIndex = moduleDirs.findIndex(dir => dir === context.cwd);
     if (workspaceIndex > -1) {
       moduleDirs.splice(workspaceIndex, 1);

--- a/lib/commands/status.js
+++ b/lib/commands/status.js
@@ -48,8 +48,8 @@ function statusCommand(argv, context) {
     console.log('\nWARNING: The current configuration may not be suitable for production builds.');
   }
 
-  if (argv.platform && (context.type === 'workspace' || context.type === 'platform')) {
-    const dev = new DevelopmentEnvironment(context.cwd, context.type === 'workspace');
+  if (argv.platform && (context.isWorkspace || context.isPlatform)) {
+    const dev = new DevelopmentEnvironment(context.cwd, context.isWorkspace);
     dev.loadExistingModules();
     const moduleDirs = dev.getModulePaths();
 

--- a/lib/commands/test/nightmare.js
+++ b/lib/commands/test/nightmare.js
@@ -13,7 +13,7 @@ function nightmareCommand(argv, context) {
     process.env.NODE_ENV = 'test';
   }
 
-  if (context.type !== 'app' && context.type !== 'platform') {
+  if (!context.isUiModule && !context.isPlatform) {
     console.log('Tests are only supported within an app or platform context.');
     return;
   }

--- a/lib/commands/workspace.js
+++ b/lib/commands/workspace.js
@@ -9,7 +9,7 @@ const { promptHandler } = importLazy('../cli/questions');
 
 
 function workspaceCommand(argv, context) {
-  if (context.type !== 'empty') {
+  if (!context.isEmpty) {
     console.log('Current directory has a package.json');
     return Promise.resolve();
   }

--- a/lib/environment/development.js
+++ b/lib/environment/development.js
@@ -90,7 +90,7 @@ module.exports = class DevelopmentEnvironment {
   // Peek up a directory and check its context to see if we're inside a workspace.
   _parentIsWorkspace() {
     const parentContext = context.getContext(path.join(this.projectDir, '..'));
-    return parentContext.type === 'workspace';
+    return parentContext.isWorkspace;
   }
 
   // Check if a module path exists outside the workspace.

--- a/test/cli/context.spec.js
+++ b/test/cli/context.spec.js
@@ -24,6 +24,7 @@ describe('The CLI\'s getContext', function () {
 
       expect(result).to.include({
         type: 'app',
+        isEmpty: false,
         isStripesModule: false,
         isUiModule: true,
         isPlatform: false,
@@ -38,6 +39,7 @@ describe('The CLI\'s getContext', function () {
 
       expect(result).to.include({
         type: 'settings',
+        isEmpty: false,
         isStripesModule: false,
         isUiModule: true,
         isPlatform: false,
@@ -52,6 +54,7 @@ describe('The CLI\'s getContext', function () {
 
       expect(result).to.include({
         type: 'components',
+        isEmpty: false,
         isStripesModule: true,
         isUiModule: false,
         isPlatform: false,
@@ -69,6 +72,7 @@ describe('The CLI\'s getContext', function () {
 
     expect(result).to.include({
       type: 'platform',
+      isEmpty: false,
       isStripesModule: false,
       isUiModule: false,
       isPlatform: true,
@@ -84,10 +88,12 @@ describe('The CLI\'s getContext', function () {
 
     expect(result).to.include({
       type: 'workspace',
+      isEmpty: false,
       isStripesModule: false,
       isUiModule: false,
       isPlatform: false,
       isBackendModule: false,
+      isWorkspace: true,
     });
   });
 
@@ -99,6 +105,7 @@ describe('The CLI\'s getContext', function () {
     const result = this.sut('someDir');
 
     expect(result).to.include({
+      isEmpty: false,
       isStripesModule: true,
       isUiModule: false,
       isPlatform: false,
@@ -114,6 +121,8 @@ describe('The CLI\'s getContext', function () {
 
     expect(result).to.include({
       type: 'cli',
+      isCli: true,
+      isEmpty: false,
       isStripesModule: false,
       isUiModule: false,
       isPlatform: false,
@@ -127,6 +136,7 @@ describe('The CLI\'s getContext', function () {
 
     expect(result).to.include({
       type: 'empty',
+      isEmpty: true,
       isStripesModule: false,
       isUiModule: false,
       isPlatform: false,

--- a/test/commands/app/create.spec.js
+++ b/test/commands/app/create.spec.js
@@ -30,7 +30,8 @@ describe('The app create command', function () {
     };
     this.context = {
       type: 'empty',
-      cwd: '/path/to/working/directory'
+      cwd: '/path/to/working/directory',
+      isEmpty: true,
     };
     this.sut = appCreateCommand;
     this.sandbox.stub(context, 'getContext').returns(this.context);
@@ -51,7 +52,8 @@ describe('The app create command', function () {
   });
 
   it('does not create an app when run from within an app', function (done) {
-    this.context.type = 'app';
+    this.context.isUiModule = true;
+    this.context.isEmpty = false;
     this.sut.handler(this.argv)
       .then(() => {
         expect(createApp.createApp).not.to.have.been.called;
@@ -72,7 +74,8 @@ describe('The app create command', function () {
 
   it('yarn installs dependencies in the workspace directory', function (done) {
     this.argv.install = true;
-    this.context.type = 'workspace';
+    this.context.isWorkspace = true;
+    this.context.isEmpty = false;
     this.sut.handler(this.argv)
       .then(() => {
         expect(yarn.install).to.have.been.calledWith('/path/to/working/directory');
@@ -93,7 +96,8 @@ describe('The app create command', function () {
 
   it('reports workspace install instructions for --no-install', function (done) {
     this.argv.install = false;
-    this.context.type = 'workspace';
+    this.context.isWorkspace = true;
+    this.context.isEmpty = false;
     this.sut.handler(this.argv)
       .then(() => {
         expect(yarn.install).not.to.have.been.called;


### PR DESCRIPTION
This refactor replaces remaining usages of `context.type` with boolean flags.  The test for "app" in particular has proven troublesome in the past as many UI modules are actually reported as "settings" or "plugin".  Checks for "app" would then fail for those modules.  Work had previously begun to replace `context.type === 'app'` with a new `context.isUiModule` boolean.  This PR completes that work for remaining usages and the other strings like "platform".

Well, there is one remaining usage, `context.type == 'components'`, which is an outlier that will be addressed by STCLI-107 and will need coordination with some `stripes-` repos.