### PR TITLE
STCLI-126 perm filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Refactor usage of context.type, STCLI-78
 * Implement CLI context, prompts, and stdin handlers as Yargs middleware, STCLI-99
 * New middleware for loading stripes config files and applying okapi/tenant, STCLI-117
+* Add support to filter permissions by assigned/unassigned, STCLI-126
 
 
 ## [1.8.0](https://github.com/folio-org/stripes-cli/tree/v1.8.0) (2019-01-16)

--- a/doc/backend-guide.md
+++ b/doc/backend-guide.md
@@ -168,10 +168,10 @@ $ cat my-module-actions | stripes mod filter --front | stripes mod install
 
 ### Assign permissions to a user
 
-In order to make use of the newly installed modules for development, assign module permissions to a user.  This can be done by chaining a few `stripes` commands together.  The following will gather permissions for all of the tenant's modules, and attempt to assign them to the user.
+In order to make use of the newly installed modules for development, assign module permissions to a user.  This can be done by chaining a few `stripes` commands together.  The following will gather permissions for all of the tenant's modules, filter permission to those the user doesn't have, and attempt to assign them to the user.
 
 ```
-$ stripes mod list | stripes mod perms | stripes perm assign --user diku_admin
+$ stripes mod list | stripes mod perms | stripes perm filter --unassigned diku_admin | stripes perm assign --user diku_admin
 ```
 
 ## Connect a local back-end module to an existing platform

--- a/doc/backend-guide.md
+++ b/doc/backend-guide.md
@@ -168,7 +168,7 @@ $ cat my-module-actions | stripes mod filter --front | stripes mod install
 
 ### Assign permissions to a user
 
-In order to make use of the newly installed modules for development, assign module permissions to a user.  This can be done by chaining a few `stripes` commands together.  The following will gather permissions for all of the tenant's modules, filter permission to those the user doesn't have, and attempt to assign them to the user.
+In order to make use of the newly installed modules for development, assign module permissions to a user.  This can be done by chaining a few `stripes` commands together.  The following will gather permissions for all of the tenant's modules, filter permissions to those the user doesn't have, and attempt to assign them to the user.
 
 ```
 $ stripes mod list | stripes mod perms | stripes perm filter --unassigned diku_admin | stripes perm assign --user diku_admin

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -34,6 +34,7 @@ This following command documentation is generated from the CLI's own built-in he
 * [`perm` command](#perm-command)
     * [`perm assign` command](#perm-assign-command)
     * [`perm create` command](#perm-create-command)
+    * [`perm filter` command](#perm-filter-command)
     * [`perm list` command](#perm-list-command)
     * [`perm unassign` command](#perm-unassign-command)
 * [`platform` command](#platform-command)
@@ -710,6 +711,7 @@ $ stripes perm <command>
 Sub-commands:
 * [`stripes perm assign`](#perm-assign-command)
 * [`stripes perm create`](#perm-create-command)
+* [`stripes perm filter`](#perm-filter-command)
 * [`stripes perm list`](#perm-list-command)
 * [`stripes perm unassign`](#perm-unassign-command)
 
@@ -771,6 +773,32 @@ $ stripes perm create ui-my-app.example
 Create a new permission, update the module descriptor, and assign permission to user someone:
 ```
 $ stripes perm create ui-my-app.example --push --assign someone
+```
+
+### `perm filter` command
+
+Filter permissions
+
+Usage:
+```
+$ stripes perm filter
+```
+
+Option | Description | Type | Notes
+---|---|---|---
+`--assigned` | User to filter by assigned | string |
+`--name` | Names of the permissions to filter  | array | supports stdin
+`--unassigned` | User to filter by unassigned | string |
+
+Examples:
+
+Filter by assigned permissions:
+```
+$ echo one two | stripes perm filter --assigned diku_admin
+```
+Filter by unassigned permissions:
+```
+$ echo one two | stripes perm filter --unassigned diku_admin
 ```
 
 ### `perm list` command

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -38,7 +38,7 @@ This following command documentation is generated from the CLI's own built-in he
     * [`perm list` command](#perm-list-command)
     * [`perm unassign` command](#perm-unassign-command)
 * [`platform` command](#platform-command)
-    * [`platform backend` command (work in progress)](#platform-backend-command-work-in-progress)
+    * [`platform backend` command](#platform-backend-command)
     * [`platform clean` command](#platform-clean-command)
     * [`platform install` command](#platform-install-command)
     * [`platform pull` command](#platform-pull-command)
@@ -856,14 +856,14 @@ $ stripes platform <command>
 ```
 
 Sub-commands:
-* [`stripes platform backend`](#platform-backend-command-work-in-progress)
+* [`stripes platform backend`](#platform-backend-command)
 * [`stripes platform clean`](#platform-clean-command)
 * [`stripes platform install`](#platform-install-command)
 * [`stripes platform pull`](#platform-pull-command)
 
-### `platform backend` command (work in progress)
+### `platform backend` command
 
-Initialize Okapi backend for a platform (work in progress)
+Initialize Okapi backend for a platform
 
 Usage:
 ```

--- a/lib/commands/perm/filter.js
+++ b/lib/commands/perm/filter.js
@@ -1,0 +1,51 @@
+const importLazy = require('import-lazy')(require);
+
+const Okapi = importLazy('../../okapi');
+const PermissionService = importLazy('../../okapi/permission-service');
+const { stdinArrayMiddleware } = importLazy('../../cli/stdin-middleware');
+
+
+function filterPermissionsCommand(argv, context) {
+  const okapi = new Okapi(argv.okapi, argv.tenant);
+  const permissionService = new PermissionService(okapi, context);
+
+  if (!argv.assigned && !argv.unassigned) {
+    console.log('A filter must be specified');
+    return;
+  }
+
+  const filteredPromise = argv.assigned
+    ? permissionService.filterAssignedPermissions(argv.name, argv.assigned)
+    : permissionService.filterUnassignedPermissions(argv.name, argv.unassigned);
+
+  filteredPromise.then(permissions => permissions.forEach(perm => console.log(perm)));
+}
+
+module.exports = {
+  command: 'filter',
+  describe: 'Filter permissions',
+  builder: (yargs) => {
+    yargs
+      .middleware([
+        stdinArrayMiddleware('name'),
+      ])
+      .option('name', {
+        describe: 'Names of the permissions to filter (stdin)',
+        type: 'array',
+      })
+      .option('assigned', {
+        describe: 'User to filter by assigned',
+        type: 'string',
+        conflicts: 'unassigned',
+      })
+      .option('unassigned', {
+        describe: 'User to filter by unassigned',
+        type: 'string',
+        conflicts: 'assigned',
+      })
+      .example('echo one two | $0 perm filter --assigned diku_admin', 'Filter by assigned permissions')
+      .example('echo one two | $0 perm filter --unassigned diku_admin', 'Filter by unassigned permissions');
+    return yargs;
+  },
+  handler: filterPermissionsCommand,
+};

--- a/lib/commands/platform/backend.js
+++ b/lib/commands/platform/backend.js
@@ -114,7 +114,7 @@ async function backendInstallCommand(argv) {
 
 module.exports = {
   command: 'backend <configFile>',
-  describe: 'Initialize Okapi backend for a platform (work in progress)',
+  describe: 'Initialize Okapi backend for a platform',
   builder: (yargs) => {
     yargs
       .middleware([

--- a/lib/okapi/permission-service.js
+++ b/lib/okapi/permission-service.js
@@ -102,12 +102,21 @@ module.exports = class PermissionService {
       });
   }
 
+  filterAssignedPermissions(permissions, username) {
+    return this.listPermissionsForUser(username)
+      .then((userPermissions) => permissions.filter(perm => userPermissions.includes(perm)));
+  }
+
+  filterUnassignedPermissions(permissions, username) {
+    return this.listPermissionsForUser(username)
+      .then((userPermissions) => permissions.filter(perm => !userPermissions.includes(perm)));
+  }
+
   // Gather all permissions for this tenant's modules and assign them to a user
   async assignAllTenantPermissionsToUser(tenant, username) {
-    const userPermissions = await this.listPermissionsForUser(username);
     const tenantModuleIds = await this.moduleService.listModulesForTenant(tenant);
     const modulePermissions = await this.moduleService.listModulePermissions(tenantModuleIds, false);
-    const permissionsToAssign = modulePermissions.filter(perm => !userPermissions.includes(perm));
+    const permissionsToAssign = await this.filterUnassignedPermissions(modulePermissions, username);
     const assignmentResponses = await this.assignPermissionsToUser(permissionsToAssign, username);
 
     return assignmentResponses.filter(response => !response.alreadyExists).map(response => response.id);

--- a/test/okapi/permission-service.spec.js
+++ b/test/okapi/permission-service.spec.js
@@ -309,6 +309,38 @@ describe('The permission-service', function () {
     });
   });
 
+  describe('filterAssignedPermissions method', function () {
+    beforeEach(function () {
+      this.sut = new PermissionService(okapiStub, contextStub);
+    });
+
+    it('Returns assigned permissions', function (done) {
+      this.sut.filterAssignedPermissions(['one.foo', 'two.bar', 'three.foo', 'three.bar'], 'diku_admin')
+        .then((results) => {
+          expect(results).to.be.an('array').with.lengthOf(2);
+          expect(results).to.include.members(['one.foo', 'two.bar']);
+          expect(results).to.not.include('three.foo').and.not.include('three.bar');
+          done();
+        });
+    });
+  });
+
+  describe('filterUnassignedPermissions method', function () {
+    beforeEach(function () {
+      this.sut = new PermissionService(okapiStub, contextStub);
+    });
+
+    it('Returns unassigned permissions', function (done) {
+      this.sut.filterUnassignedPermissions(['one.foo', 'two.bar', 'three.foo', 'three.bar'], 'diku_admin')
+        .then((results) => {
+          expect(results).to.be.an('array').with.lengthOf(2);
+          expect(results).to.include.members(['three.foo', 'three.bar']);
+          expect(results).to.not.include('one.foo').and.not.include('two.bar');
+          done();
+        });
+    });
+  });
+
   describe('assignAllTenantPermissionsToUser method', function () {
     beforeEach(function () {
       this.sut = new PermissionService(okapiStub, contextStub);


### PR DESCRIPTION
By exposing the filtering logic from `platform backend` as its own command, the individual steps outlined in the backend-guide can be performed without unnecessary permission calls.