### PR TITLE
Don't check stdin for a config file when running tests

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -23,7 +23,7 @@ module.exports = {
     yargs
       .middleware([
         contextMiddleware(),
-        stripesConfigMiddleware()
+        stripesConfigMiddleware(true)
       ])
       .commandDir('test', commandDirOptions)
       .positional('configFile', stripesConfigFile.configFile)

--- a/lib/commands/test/karma.js
+++ b/lib/commands/test/karma.js
@@ -46,7 +46,7 @@ module.exports = {
     yargs
       .middleware([
         contextMiddleware(),
-        stripesConfigMiddleware(),
+        stripesConfigMiddleware(true),
       ])
       .positional('configFile', stripesConfigFile.configFile)
       .option('coverage', {

--- a/lib/commands/test/nightmare.js
+++ b/lib/commands/test/nightmare.js
@@ -104,7 +104,7 @@ module.exports = {
     yargs
       .middleware([
         contextMiddleware(),
-        stripesConfigMiddleware(),
+        stripesConfigMiddleware(true),
       ])
       .positional('configFile', stripesConfigFile.configFile)
       .option('run', {


### PR DESCRIPTION
This is a quick fix to see if it resolves a testing issue on Jenkins.  A more complete solution will follow.