### PR TITLE
STCLI-131 check tty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change history for stripes-cli
 
 
+## [1.10.0] (IN PROGRESS)
+* Check for TTY before calling getStdin(), fixes STCLI-131
+
+
 ## [1.9.0](https://github.com/folio-org/stripes-cli/tree/v1.9.0) (2019-02-13)
 
 * Facilitate connection of a locally hosted back-end module with Okapi, STCLI-114

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -1052,7 +1052,6 @@ Option | Description | Type | Notes
 `--languages` | Languages to include in tenant build | array |
 `--okapi` | Specify an Okapi URL | string |
 `--port` | Development server port | number | default: 3000
-`--stripesConfig` | Stripes config JSON  | string | supports stdin
 `--tenant` | Specify a tenant ID | string |
 
 Examples:

--- a/lib/cli/prompt-middleware.js
+++ b/lib/cli/prompt-middleware.js
@@ -30,7 +30,7 @@ function askIfUndefined(argv, yargsOptions) {
     }
   });
   const questions = yargsToInquirer(askFor);
-  if (questions.length && process.stdout.isTTY && argv.interactive) {
+  if (questions.length && argv.interactive) {
     return inquirer.prompt(questions).then(answers => Object.assign({}, argv, answers));
   } else {
     return Promise.resolve(argv);

--- a/lib/cli/prompt-middleware.js
+++ b/lib/cli/prompt-middleware.js
@@ -30,7 +30,7 @@ function askIfUndefined(argv, yargsOptions) {
     }
   });
   const questions = yargsToInquirer(askFor);
-  if (questions.length && argv.interactive) {
+  if (questions.length && process.stdout.isTTY && argv.interactive) {
     return inquirer.prompt(questions).then(answers => Object.assign({}, argv, answers));
   } else {
     return Promise.resolve(argv);

--- a/lib/cli/stdin.js
+++ b/lib/cli/stdin.js
@@ -1,6 +1,17 @@
 const getStdin = require('get-stdin');
 
+function stdinWrapper() {
+  // Per Node docs, the preferred method of determining whether Node.js is being run within
+  // a TTY context is to check that the value of the process.stdout.isTTY property is true
+  // (https://nodejs.org/docs/latest-v8.x/api/tty.html)
+  if (process.stdout.isTTY) {
+    return getStdin();
+  } else {
+    return Promise.resolve();
+  }
+}
+
 // Wrapper to facilitate testing
 module.exports = {
-  getStdin,
+  getStdin: stdinWrapper,
 };

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -2,7 +2,7 @@ const importLazy = require('import-lazy')(require);
 
 const { contextMiddleware } = importLazy('../cli/context-middleware');
 const { stripesConfigMiddleware } = importLazy('../cli/stripes-config-middleware');
-const { serverOptions, okapiOptions, stripesConfigFile, stripesConfigStdin, stripesConfigOptions } = importLazy('./common-options');
+const { serverOptions, okapiOptions, stripesConfigFile, stripesConfigOptions } = importLazy('./common-options');
 const nightmareCommand = importLazy('./test/nightmare').handler;
 const karmaCommand = importLazy('./test/karma').handler;
 const { commandDirOptions } = importLazy('../cli/config');
@@ -27,7 +27,7 @@ module.exports = {
       ])
       .commandDir('test', commandDirOptions)
       .positional('configFile', stripesConfigFile.configFile)
-      .options(Object.assign({}, serverOptions, okapiOptions, stripesConfigStdin, stripesConfigOptions))
+      .options(Object.assign({}, serverOptions, okapiOptions, stripesConfigOptions))
       .example('$0 test nightmare --run=demo', 'Serve app and run it\'s demo.js Nightmare tests')
       .example('$0 test karma', 'Run Karma tests for the current app module');
   },

--- a/lib/commands/test/karma.js
+++ b/lib/commands/test/karma.js
@@ -46,7 +46,7 @@ module.exports = {
     yargs
       .middleware([
         contextMiddleware(),
-        stripesConfigMiddleware(true),
+        stripesConfigMiddleware(),
       ])
       .positional('configFile', stripesConfigFile.configFile)
       .option('coverage', {

--- a/lib/commands/test/nightmare.js
+++ b/lib/commands/test/nightmare.js
@@ -104,7 +104,7 @@ module.exports = {
     yargs
       .middleware([
         contextMiddleware(),
-        stripesConfigMiddleware(true),
+        stripesConfigMiddleware(),
       ])
       .positional('configFile', stripesConfigFile.configFile)
       .option('run', {


### PR DESCRIPTION
This adds a check for TTY before attempting to call getStdin().  Without TTY, the call would hang resulting in FOLIO-1807.  The previous quick fix has been rolled back as its no longer needed.  That fix manually disabled the getStdin() call for selected commands, whereas this solution handles it automatically for any command based on the presence of TTY.