### PR TITLE
STCLI-84 mocha reporter option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## [1.10.0] (IN PROGRESS)
 * Check for TTY before calling getStdin(), fixes STCLI-131
 * Update ui-module blueprint to use stripes 2.0
+* Add mocha-jenkins-reporter and support passing of `--reporter` option for Nightmare tests, STCLI-84
 
 
 ## [1.9.0](https://github.com/folio-org/stripes-cli/tree/v1.9.0) (2019-02-13)

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -1120,6 +1120,7 @@ Option | Description | Type | Notes
 `--local` | Shortcut for --url http://localhost:3000 | boolean |
 `--okapi` | Specify an Okapi URL | string |
 `--port` | Development server port | number | default: 3000
+`--reporter` | Specify a Mocha reporter |  |
 `--run` | Name of the test script to run | string |
 `--show` | Show UI and dev tools while running tests | boolean |
 `--stripesConfig` | Stripes config JSON  | string | supports stdin

--- a/lib/commands/test/nightmare.js
+++ b/lib/commands/test/nightmare.js
@@ -128,6 +128,9 @@ module.exports = {
       .option('uiTest', {
         describe: 'Additional options for ui-testing framework',
       })
+      .option('reporter', {
+        describe: 'Specify a Mocha reporter',
+      })
       .options(Object.assign({}, serverOptions, okapiOptions, stripesConfigStdin, stripesConfigOptions))
       .example('$0 test nightmare', 'Serve app or platform and run all of its Nightmare tests')
       .example('$0 test nightmare --run demo', 'Serve app or platform and run its demo.js Nightmare tests')

--- a/lib/test/nightmare-service.js
+++ b/lib/test/nightmare-service.js
@@ -81,6 +81,9 @@ module.exports = class NightmareService {
     if (options.coverage) {
       this.testArgs.push('--coverage');
     }
+    if (options.reporter) {
+      this.testArgs.push('--reporter', options.reporter);
+    }
 
     // Apply args for ui-testing
     if (options.uiTest && typeof options.uiTest === 'object') {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "kopy": "^8.2.3",
     "lodash": "^4.17.5",
     "mocha": "^5.2.0",
+    "mocha-jenkins-reporter": "^0.4.1",
     "node-fetch-npm": "^2.0.2",
     "nyc": "^12.0.2",
     "resolve-from": "^4.0.0",


### PR DESCRIPTION
This allows the CLI to pass the `--reporter` option to Mocha when running Nightmare integration tests.  The `mocha-jenkins-reporter` has been made available as well.