### PR TITLE
STCLI-132 serve doc corrections

### DIFF
--- a/doc/commands.md
+++ b/doc/commands.md
@@ -209,7 +209,6 @@ Positional | Description | Type | Notes
 Option | Description | Type | Notes
 ---|---|---|---
 `--analyze` | Run the Webpack Bundle Analyzer after build (launches in browser) | boolean |
-`--dev` | Use development build settings | boolean |
 `--devtool` | Specify the Webpack devtool for generating source maps | string |
 `--hasAllPerms` | Set "hasAllPerms" in Stripes config | boolean |
 `--languages` | Languages to include in tenant build | array |
@@ -218,7 +217,6 @@ Option | Description | Type | Notes
 `--minify` | Minify the bundle output | boolean | default: true
 `--okapi` | Specify an Okapi URL | string |
 `--output` | Directory to place build output | string |
-`--prod` | Use production build settings | boolean |
 `--publicPath` | Specify the Webpack publicPath output option | string |
 `--sourcemap` | Include sourcemaps in build output | boolean |
 `--stripesConfig` | Stripes config JSON  | string | supports stdin
@@ -971,7 +969,6 @@ Positional | Description | Type | Notes
 Option | Description | Type | Notes
 ---|---|---|---
 `--cache` | Use HardSourceWebpackPlugin cache | boolean |
-`--dev` | Use development build settings | boolean |
 `--devtool` | Specify the Webpack devtool for generating source maps | string |
 `--existing-build` | Serve an existing build from the supplied directory | string |
 `--hasAllPerms` | Set "hasAllPerms" in Stripes config | boolean |
@@ -982,8 +979,6 @@ Option | Description | Type | Notes
 `--mirage [scenario]` | Enable Mirage Server when available and optionally specify a scenario | string |
 `--okapi` | Specify an Okapi URL | string |
 `--port` | Development server port | number | default: 3000
-`--prod` | Use production build settings | boolean |
-`--publicPath` | Specify the Webpack publicPath output option | string |
 `--stripesConfig` | Stripes config JSON  | string | supports stdin
 `--tenant` | Specify a tenant ID | string |
 

--- a/lib/commands/common-options.js
+++ b/lib/commands/common-options.js
@@ -104,18 +104,18 @@ module.exports.stripesConfigOptions = {
 };
 
 module.exports.buildOptions = {
-  prod: {
-    type: 'boolean',
-    describe: 'Use production build settings',
-    conflicts: 'dev',
-    default: undefined,
-  },
-  dev: {
-    type: 'boolean',
-    describe: 'Use development build settings',
-    conflicts: 'prod',
-    default: undefined,
-  },
+  // prod: {
+  //   type: 'boolean',
+  //   describe: 'Use production build settings',
+  //   conflicts: 'dev',
+  //   default: undefined,
+  // },
+  // dev: {
+  //   type: 'boolean',
+  //   describe: 'Use development build settings',
+  //   conflicts: 'prod',
+  //   default: undefined,
+  // },
   publicPath: {
     describe: 'Specify the Webpack publicPath output option',
     type: 'string',

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -8,6 +8,9 @@ const { serverOptions, okapiOptions, stripesConfigFile, stripesConfigStdin, stri
 const { processError, emitLintWarnings, limitChunks, enableMirage } = importLazy('../webpack-common');
 const server = importLazy('../server');
 
+// stripes-core does not currently support publicPath with the dev server
+const serveBuildOptions = Object.assign({}, buildOptions);
+delete serveBuildOptions.publicPath;
 
 function serveCommand(argv) {
   const context = argv.context;
@@ -83,7 +86,7 @@ module.exports = {
         describe: 'Enable Mirage Server when available and optionally specify a scenario',
         type: 'string',
       })
-      .options(Object.assign({}, serverOptions, okapiOptions, stripesConfigStdin, stripesConfigOptions, buildOptions))
+      .options(Object.assign({}, serverOptions, okapiOptions, stripesConfigStdin, stripesConfigOptions, serveBuildOptions))
       .example('$0 serve --hasAllPerms', 'Serve an app (in app context) with permissions flag set for development')
       .example('$0 serve stripes.config.js', 'Serve a platform defined by the supplied configuration')
       .example('$0 serve --existing-build output', 'Serve a build previously created with "stripes build"')


### PR DESCRIPTION
The CLI defines some build/serve options that are not currently implemented in stripes-core.  These options have been removed and the documentation regenerated to avoid confusion.