### PR TITLE
STCLI-135 Added Okapi path accessor commands

### DIFF
--- a/doc/commands.md
+++ b/doc/commands.md
@@ -742,15 +742,16 @@ $ stripes okapi get /users/123-456
 
 ### `okapi post` command
 
-Perform an HTTP POST request with JSON payload on stdin to a given Okapi endpoint
+Perform an HTTP POST request with a payload from JSON file/stdin a given Okapi endpoint
 
 Usage:
 ```
-$ stripes okapi post <path>
+$ stripes okapi post <path> [file]
 ```
 
 Positional | Description | Type | Notes
 ---|---|---|---
+`file` | File containing JSON data | string |
 `path` | The Okapi path or endpoint to operate on. | string | required
 
 Option | Description | Type | Notes
@@ -768,15 +769,16 @@ $ stripes okapi post /users
 
 ### `okapi put` command
 
-Perform an HTTP PUT request with JSON payload on stdin sto a given Okapi endpoint
+Perform an HTTP PUT request with a payload from JSON file/stdin a given Okapi endpoint
 
 Usage:
 ```
-$ stripes okapi put <path>
+$ stripes okapi put <path> [file]
 ```
 
 Positional | Description | Type | Notes
 ---|---|---|---
+`file` | File containing JSON data | string |
 `path` | The Okapi path or endpoint to operate on. | string | required
 
 Option | Description | Type | Notes

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -756,7 +756,7 @@ Positional | Description | Type | Notes
 
 Option | Description | Type | Notes
 ---|---|---|---
-`--body` | The JSON to POST to the endpoint | string |
+`--body` | The JSON to POST to the endpoint  | string | supports stdin
 `--okapi` | Specify an Okapi URL | string |
 `--tenant` | Specify a tenant ID | string |
 
@@ -783,7 +783,7 @@ Positional | Description | Type | Notes
 
 Option | Description | Type | Notes
 ---|---|---|---
-`--body` | The JSON to PUT to the endpoint | string |
+`--body` | The JSON to PUT to the endpoint  | string | supports stdin
 `--okapi` | Specify an Okapi URL | string |
 `--tenant` | Specify a tenant ID | string |
 

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -30,6 +30,10 @@ This following command documentation is generated from the CLI's own built-in he
 * [`okapi` command](#okapi-command)
     * [`okapi login` command](#okapi-login-command)
     * [`okapi logout` command](#okapi-logout-command)
+    * [`okapi delete` command](#okapi-delete-command)
+    * [`okapi get` command](#okapi-get-command)
+    * [`okapi post` command](#okapi-post-command)
+    * [`okapi put` command](#okapi-put-command)
     * [`okapi token` command](#okapi-token-command)
 * [`perm` command](#perm-command)
     * [`perm assign` command](#perm-assign-command)
@@ -641,6 +645,10 @@ $ stripes okapi <command>
 Sub-commands:
 * [`stripes okapi login`](#okapi-login-command)
 * [`stripes okapi logout`](#okapi-logout-command)
+* [`stripes okapi delete`](#okapi-delete-command)
+* [`stripes okapi get`](#okapi-get-command)
+* [`stripes okapi post`](#okapi-post-command)
+* [`stripes okapi put`](#okapi-put-command)
 * [`stripes okapi token`](#okapi-token-command)
 
 ### `okapi login` command
@@ -680,6 +688,108 @@ Clear previously saved Okapi token.
 Usage:
 ```
 $ stripes okapi logout
+```
+
+### `okapi delete` command
+
+Perform an HTTP DELETE request to a given Okapi endpoint
+
+Usage:
+```
+$ stripes okapi delete <path>
+```
+
+Positional | Description | Type | Notes
+---|---|---|---
+`path` | The Okapi path or endpoint to operate on. | string | required
+
+Option | Description | Type | Notes
+---|---|---|---
+`--okapi` | Specify an Okapi URL | string |
+`--tenant` | Specify a tenant ID | string |
+
+Examples:
+
+Perform a DELETE request to the "/users/123-456" path:
+```
+$ stripes okapi delete /users/123-456
+```
+
+### `okapi get` command
+
+Perform an HTTP GET request to a given Okapi endpoint
+
+Usage:
+```
+$ stripes okapi get <path>
+```
+
+Positional | Description | Type | Notes
+---|---|---|---
+`path` | The Okapi path or endpoint to operate on. | string | required
+
+Option | Description | Type | Notes
+---|---|---|---
+`--okapi` | Specify an Okapi URL | string |
+`--tenant` | Specify a tenant ID | string |
+
+Examples:
+
+Perform a GET request to the "/users/123-456" path:
+```
+$ stripes okapi get /users/123-456
+```
+
+### `okapi post` command
+
+Perform an HTTP POST request with JSON payload on stdin to a given Okapi endpoint
+
+Usage:
+```
+$ stripes okapi post <path>
+```
+
+Positional | Description | Type | Notes
+---|---|---|---
+`path` | The Okapi path or endpoint to operate on. | string | required
+
+Option | Description | Type | Notes
+---|---|---|---
+`--body` | The JSON to POST to the endpoint | string |
+`--okapi` | Specify an Okapi URL | string |
+`--tenant` | Specify a tenant ID | string |
+
+Examples:
+
+Perform a POST request to the "/users" path:
+```
+$ stripes okapi post /users
+```
+
+### `okapi put` command
+
+Perform an HTTP PUT request with JSON payload on stdin sto a given Okapi endpoint
+
+Usage:
+```
+$ stripes okapi put <path>
+```
+
+Positional | Description | Type | Notes
+---|---|---|---
+`path` | The Okapi path or endpoint to operate on. | string | required
+
+Option | Description | Type | Notes
+---|---|---|---
+`--body` | The JSON to PUT to the endpoint | string |
+`--okapi` | Specify an Okapi URL | string |
+`--tenant` | Specify a tenant ID | string |
+
+Examples:
+
+Perform a PUT request to the "/users/123-456" path:
+```
+$ stripes okapi put /users/123-456
 ```
 
 ### `okapi token` command

--- a/lib/commands/common-options.js
+++ b/lib/commands/common-options.js
@@ -133,3 +133,16 @@ module.exports.buildOptions = {
     describe: 'Limit the number of Webpack chunks in build output',
   },
 };
+
+const pathOptions = {
+  path: {
+    describe: 'The Okapi path or endpoint to operate on.',
+    type: 'string',
+  },
+};
+
+module.exports.pathOptions = pathOptions;
+
+module.exports.pathRequired = {
+  path: Object.assign({}, pathOptions.path, { required: true }),
+};

--- a/lib/commands/common-options.js
+++ b/lib/commands/common-options.js
@@ -153,4 +153,3 @@ module.exports.fileOptions = {
     describe: 'File containing JSON data',
   },
 };
-

--- a/lib/commands/common-options.js
+++ b/lib/commands/common-options.js
@@ -146,3 +146,11 @@ module.exports.pathOptions = pathOptions;
 module.exports.pathRequired = {
   path: Object.assign({}, pathOptions.path, { required: true }),
 };
+
+module.exports.fileOptions = {
+  json: {
+    type: 'string',
+    describe: 'File containing JSON data',
+  },
+};
+

--- a/lib/commands/okapi/pathDelete.js
+++ b/lib/commands/okapi/pathDelete.js
@@ -1,0 +1,28 @@
+const importLazy = require('import-lazy')(require);
+
+const EndpointService = importLazy('../../okapi/endpoint-service');
+const { okapiOptions, pathRequired, tenantOption } = importLazy('../common-options');
+
+
+function pathDeleteCommand(argv) {
+  const endpointService = new EndpointService(argv.okapi, argv.tenant);
+
+  const promise = endpointService.delete(argv.path);
+
+  return promise
+    .then((success) => {
+      console.log(`DELETE ${success ? 'succeeded' : 'failed'}.`);
+    });
+}
+
+module.exports = {
+  command: 'delete <path>',
+  describe: 'Perform an HTTP DELETE request to a given Okapi endpoint',
+  builder: (yargs) => {
+    yargs
+      .positional('path', pathRequired.path)
+      .options(Object.assign({}, okapiOptions, tenantOption))
+      .example('$0 okapi delete /users/123-456', 'Perform a DELETE request to the "/users/123-456" path');
+  },
+  handler: pathDeleteCommand,
+};

--- a/lib/commands/okapi/pathGet.js
+++ b/lib/commands/okapi/pathGet.js
@@ -1,0 +1,28 @@
+const importLazy = require('import-lazy')(require);
+
+const EndpointService = importLazy('../../okapi/endpoint-service');
+const { okapiOptions, pathRequired, tenantOption } = importLazy('../common-options');
+
+
+function pathGetCommand(argv) {
+  const endpointService = new EndpointService(argv.okapi, argv.tenant);
+
+  const promise = endpointService.get(argv.path);
+
+  return promise
+    .then((response) => {
+      console.log(response);
+    });
+}
+
+module.exports = {
+  command: 'get <path>',
+  describe: 'Perform an HTTP GET request to a given Okapi endpoint',
+  builder: (yargs) => {
+    yargs
+      .positional('path', pathRequired.path)
+      .options(Object.assign({}, okapiOptions, tenantOption))
+      .example('$0 okapi get /users/123-456', 'Perform a GET request to the "/users/123-456" path');
+  },
+  handler: pathGetCommand,
+};

--- a/lib/commands/okapi/pathPost.js
+++ b/lib/commands/okapi/pathPost.js
@@ -31,7 +31,7 @@ function pathPostCommand(argv) {
 
 module.exports = {
   command: 'post <path> [file]',
-  describe: 'Perform an HTTP POST request with JSON payload on stdin to a given Okapi endpoint',
+  describe: 'Perform an HTTP POST request with a payload from JSON file/stdin a given Okapi endpoint',
   builder: (yargs) => {
     yargs
       .middleware([

--- a/lib/commands/okapi/pathPost.js
+++ b/lib/commands/okapi/pathPost.js
@@ -1,14 +1,27 @@
 const importLazy = require('import-lazy')(require);
 
+const fs = importLazy('fs');
+const path = importLazy('path');
+const process = importLazy('process');
+
 const { stdinJsonMiddleware } = importLazy('../../cli/stdin-middleware');
 const EndpointService = importLazy('../../okapi/endpoint-service');
-const { okapiOptions, pathRequired, tenantOption } = importLazy('../common-options');
+const { fileOptions, okapiOptions, pathRequired, tenantOption } = importLazy('../common-options');
 
 
 function pathPostCommand(argv) {
   const endpointService = new EndpointService(argv.okapi, argv.tenant);
 
-  const promise = endpointService.post(argv.path, argv.body);
+  let body = argv.body;
+
+  if (argv.file) {
+    if (fs.existsSync(argv.file)) {
+      const file = path.join(process.cwd(), argv.file);
+      body = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    }
+  }
+
+  const promise = endpointService.post(argv.path, body);
 
   return promise
     .then((response) => {
@@ -17,7 +30,7 @@ function pathPostCommand(argv) {
 }
 
 module.exports = {
-  command: 'post <path>',
+  command: 'post <path> [file]',
   describe: 'Perform an HTTP POST request with JSON payload on stdin to a given Okapi endpoint',
   builder: (yargs) => {
     yargs
@@ -25,6 +38,7 @@ module.exports = {
         stdinJsonMiddleware('body'),
       ])
       .positional('path', pathRequired.path)
+      .positional('file', fileOptions.json)
       .option('body', {
         describe: 'The JSON to POST to the endpoint',
         type: 'string',

--- a/lib/commands/okapi/pathPost.js
+++ b/lib/commands/okapi/pathPost.js
@@ -1,0 +1,36 @@
+const importLazy = require('import-lazy')(require);
+
+const { stdinJsonMiddleware } = importLazy('../../cli/stdin-middleware');
+const EndpointService = importLazy('../../okapi/endpoint-service');
+const { okapiOptions, pathRequired, tenantOption } = importLazy('../common-options');
+
+
+function pathPostCommand(argv) {
+  const endpointService = new EndpointService(argv.okapi, argv.tenant);
+
+  const promise = endpointService.post(argv.path, argv.body);
+
+  return promise
+    .then((response) => {
+      console.log(response);
+    });
+}
+
+module.exports = {
+  command: 'post <path>',
+  describe: 'Perform an HTTP POST request with JSON payload on stdin to a given Okapi endpoint',
+  builder: (yargs) => {
+    yargs
+      .middleware([
+        stdinJsonMiddleware('body'),
+      ])
+      .positional('path', pathRequired.path)
+      .option('body', {
+        describe: 'The JSON to POST to the endpoint',
+        type: 'string',
+      })
+      .options(Object.assign({}, okapiOptions, tenantOption))
+      .example('$0 okapi post /users', 'Perform a POST request to the "/users" path');
+  },
+  handler: pathPostCommand,
+};

--- a/lib/commands/okapi/pathPost.js
+++ b/lib/commands/okapi/pathPost.js
@@ -40,7 +40,7 @@ module.exports = {
       .positional('path', pathRequired.path)
       .positional('file', fileOptions.json)
       .option('body', {
-        describe: 'The JSON to POST to the endpoint',
+        describe: 'The JSON to POST to the endpoint (stdin)',
         type: 'string',
       })
       .options(Object.assign({}, okapiOptions, tenantOption))

--- a/lib/commands/okapi/pathPut.js
+++ b/lib/commands/okapi/pathPut.js
@@ -1,0 +1,36 @@
+const importLazy = require('import-lazy')(require);
+
+const { stdinJsonMiddleware } = importLazy('../../cli/stdin-middleware');
+const EndpointService = importLazy('../../okapi/endpoint-service');
+const { okapiOptions, pathRequired, tenantOption } = importLazy('../common-options');
+
+
+function pathPutCommand(argv) {
+  const endpointService = new EndpointService(argv.okapi, argv.tenant);
+
+  const promise = endpointService.put(argv.path, argv.body);
+
+  return promise
+    .then((response) => {
+      console.log(response);
+    });
+}
+
+module.exports = {
+  command: 'put <path>',
+  describe: 'Perform an HTTP PUT request with JSON payload on stdin sto a given Okapi endpoint',
+  builder: (yargs) => {
+    yargs
+      .middleware([
+        stdinJsonMiddleware('body'),
+      ])
+      .positional('path', pathRequired.path)
+      .option('body', {
+        describe: 'The JSON to PUT to the endpoint',
+        type: 'string',
+      })
+      .options(Object.assign({}, okapiOptions, tenantOption))
+      .example('$0 okapi put /users/123-456', 'Perform a PUT request to the "/users/123-456" path');
+  },
+  handler: pathPutCommand,
+};

--- a/lib/commands/okapi/pathPut.js
+++ b/lib/commands/okapi/pathPut.js
@@ -8,7 +8,16 @@ const { okapiOptions, pathRequired, tenantOption } = importLazy('../common-optio
 function pathPutCommand(argv) {
   const endpointService = new EndpointService(argv.okapi, argv.tenant);
 
-  const promise = endpointService.put(argv.path, argv.body);
+  let body = argv.body;
+
+  if (argv.file) {
+    if (fs.existsSync(argv.file)) {
+      const file = path.join(process.cwd(), argv.file);
+      body = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    }
+  }
+
+  const promise = endpointService.put(argv.path, body);
 
   return promise
     .then((response) => {
@@ -25,6 +34,7 @@ module.exports = {
         stdinJsonMiddleware('body'),
       ])
       .positional('path', pathRequired.path)
+      .positional('file', fileOptions.json)
       .option('body', {
         describe: 'The JSON to PUT to the endpoint',
         type: 'string',

--- a/lib/commands/okapi/pathPut.js
+++ b/lib/commands/okapi/pathPut.js
@@ -1,8 +1,12 @@
 const importLazy = require('import-lazy')(require);
 
+const fs = importLazy('fs');
+const path = importLazy('path');
+const process = importLazy('process');
+
 const { stdinJsonMiddleware } = importLazy('../../cli/stdin-middleware');
 const EndpointService = importLazy('../../okapi/endpoint-service');
-const { okapiOptions, pathRequired, tenantOption } = importLazy('../common-options');
+const { fileOptions, okapiOptions, pathRequired, tenantOption } = importLazy('../common-options');
 
 
 function pathPutCommand(argv) {
@@ -26,8 +30,8 @@ function pathPutCommand(argv) {
 }
 
 module.exports = {
-  command: 'put <path>',
-  describe: 'Perform an HTTP PUT request with JSON payload on stdin sto a given Okapi endpoint',
+  command: 'put <path> [file]',
+  describe: 'Perform an HTTP PUT request with a payload from JSON file/stdin a given Okapi endpoint',
   builder: (yargs) => {
     yargs
       .middleware([

--- a/lib/commands/okapi/pathPut.js
+++ b/lib/commands/okapi/pathPut.js
@@ -40,7 +40,7 @@ module.exports = {
       .positional('path', pathRequired.path)
       .positional('file', fileOptions.json)
       .option('body', {
-        describe: 'The JSON to PUT to the endpoint',
+        describe: 'The JSON to PUT to the endpoint (stdin)',
         type: 'string',
       })
       .options(Object.assign({}, okapiOptions, tenantOption))

--- a/lib/okapi/endpoint-service.js
+++ b/lib/okapi/endpoint-service.js
@@ -1,0 +1,37 @@
+const OkapiClient = require('./okapi-client');
+
+const parseJson = data => data.json();
+const stringifyJson = data => JSON.stringify(data, null, '  ');
+
+module.exports = class EndpointService {
+  constructor(okapi, tenant) {
+    this.client = new OkapiClient(okapi, tenant);
+  }
+
+  get(path) {
+    return this.client
+      .get(path)
+      .then(parseJson)
+      .then(stringifyJson);
+  }
+
+  post(path, body) {
+    return this.client
+      .post(path, body)
+      .then(parseJson)
+      .then(stringifyJson);
+  }
+
+  put(path, body) {
+    return this.client
+      .put(path, body)
+      .then(parseJson)
+      .then(stringifyJson);
+  }
+
+  delete(path) {
+    return this.client
+      .delete(path)
+      .then(response => response.status >= 200 && response.status < 300);
+  }
+};

--- a/lib/okapi/endpoint-service.js
+++ b/lib/okapi/endpoint-service.js
@@ -32,6 +32,7 @@ module.exports = class EndpointService {
   delete(path) {
     return this.client
       .delete(path)
-      .then(response => response.status >= 200 && response.status < 300);
+      .then(() => true)
+      .catch(() => false);
   }
 };


### PR DESCRIPTION
Following through on [this Slack thread](https://folio-project.slack.com/archives/C210RP0T1/p1553879215109100) and the [subsequent JIRA issue](https://issues.folio.org/browse/STCLI-135).

First time mucking around in the guts of stripes-cli, so feel free to be exhaustive with any issues in this PR.

One thing that I wasn't sure about was using the `stdinJsonMiddleware` over the `stdinStringMiddleware` for the POST/PUT body. I went with JSON because most use cases of POST/PUT will be for JSON content and the backend complains if I just throw the text I get from `stdinStringMiddleware` at it.