### PR TITLE
FOLIO-360 Use current initial year of creation in template

### DIFF
--- a/resources/ui-app/README.md
+++ b/resources/ui-app/README.md
@@ -1,6 +1,6 @@
 # <%= uiAppName %>
 
-Copyright (C) 2018 The Open Library Foundation
+Copyright (C) 2019 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License, Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
 


### PR DESCRIPTION
In the "ui-app" template, use the current year as the initial year of creation [FOLIO-360](https://issues.folio.org/browse/FOLIO-360) (thereafter use range of years).

Perhaps this could be automated.