### PR TITLE
upgrade inquirer dependency to latest release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change history for stripes-cli
 
+## 1.11.0 (IN PROGRESS)
+* Upgrade inquirer dependency. Resolves STCLI-136
 
 ## [1.10.0](https://github.com/folio-org/stripes-cli/tree/v1.10.0) (2019-03-06)
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "global-dirs": "^0.1.1",
     "http-server": "^0.11.1",
     "import-lazy": "^3.1.0",
-    "inquirer": "^4.0.2",
+    "inquirer": "^6.3.1",
     "is-installed-globally": "^0.1.0",
     "is-path-inside": "^1.0.1",
     "just-kebab-case": "^1.0.0",


### PR DESCRIPTION
## Problem: 
On windows 10, Node LTS, the workspace command hangs after module selection.
If modules are explicitly provided to the command via the `--modules` parameter, it pulls the modules and proceeds as expected.