### PR TITLE
include tenant-settings in module list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for stripes-cli
 
+## [1.12.0](https://github.com/folio-org/stripes-cli/tree/v1.12.0) (2019-05-15)
+
+* Upgrade stripes-testing dependency. Refs STCLI-137.
+* Include ui-tenant-settings in `lib/environment`, exposing it as testable.
+
 ## [1.11.0](https://github.com/folio-org/stripes-cli/tree/v1.11.0) (2019-05-14)
 
 * New `okapi get/post/put/delete` commands to support arbitrary Okapi HTTP requests, STCLI-135

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [1.12.0](https://github.com/folio-org/stripes-cli/tree/v1.12.0) (2019-05-15)
 
-* Upgrade stripes-testing dependency. Refs STCLI-137.
+* Upgrade stripes-testing dependency to `v1.5.0`.
 * Include ui-tenant-settings in `lib/environment`, exposing it as testable.
 
 ## [1.11.0](https://github.com/folio-org/stripes-cli/tree/v1.11.0) (2019-05-14)

--- a/lib/environment/inventory.js
+++ b/lib/environment/inventory.js
@@ -23,6 +23,7 @@ const uiModules = [
   'ui-search',
   'ui-servicepoints',
   'ui-tags',
+  'ui-tenant-settings',
   'ui-trivial',
   'ui-users',
   'ui-vendors',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-cli",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Stripes Command Line Interface",
   "repository": "https://github.com/folio-org/stripes-cli",
   "publishConfig": {
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@folio/stripes-core": "^2.17.1 || ^3.0.0",
-    "@folio/stripes-testing": "^1.4.0",
+    "@folio/stripes-testing": "^1.5.0",
     "babel-plugin-istanbul": "^4.1.6",
     "configstore": "^3.1.1",
     "debug": "^4.0.1",


### PR DESCRIPTION
ui-tenant-settings will replace ui-organization (ui-vendors is being
renamed to ui-organizations and that seemed confusing). Including it
here makes it available to stripes-testing as a module potentially
containing integration tests.

Refs [UIORG-156](https://issues.folio.org/browse/UIORG-156)