### PR TITLE
upgrade dep to avoid vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-cli
 
+## 1.13.0 (IN PROGRESS)
+
+* Upgrade bundle analyzer to avoid security vulnerability WS-2019-0058.
+
 ## [1.12.0](https://github.com/folio-org/stripes-cli/tree/v1.12.0) (2019-05-15)
 
 * Upgrade stripes-testing dependency to `v1.5.0`.

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "supports-color": "^4.5.0",
     "update-notifier": "^2.3.0",
     "webpack": "^4.10.2",
-    "webpack-bundle-analyzer": "^3.0.1",
+    "webpack-bundle-analyzer": "^3.3.2",
     "yargs": "^13.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
GitHub reports a security vulnerability in webpack-bundle-analyzer,
WS-2019-0058.