### PR TITLE
Added handling for actsAs in module type check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-cli
 
+## IN PROGRESS
+
+* Added checking of `stripes.actsAs` when determining `isUiModule`, handles STCOR-148
+
 ## [1.12.1](https://github.com/folio-org/stripes-cli/tree/v1.12.1) (2019-06-11)
 
 * Upgrade bundle analyzer to avoid security vulnerability WS-2019-0058.

--- a/lib/cli/context.js
+++ b/lib/cli/context.js
@@ -21,8 +21,14 @@ function isGlobalYarn() {
   return isPathInside(__dirname, globalDirs.yarn.packages);
 }
 
-function isUiModule(type) {
-  return ['app', 'settings', 'plugin'].some(val => val === type);
+function isUiModule(actsAs) {
+  const uiModuleTypes = ['app', 'settings', 'plugin'];
+
+  // Backwards compatibility for modules using the `type` string property instead
+  // of the new `actsAs` array.
+  const types = Array.isArray(actsAs) ? actsAs : [actsAs];
+
+  return types.some(type => uiModuleTypes.find(uiModuleType => uiModuleType === type) !== undefined);
 }
 
 function isStripesModule(name) {
@@ -95,10 +101,11 @@ function getContext(dir) {
 
   // Package.json with stripes metadata, assume this is an app
   if (cwdPackageJson.stripes) {
+    ctx.actsAs = cwdPackageJson.stripes.actsAs;
     ctx.type = cwdPackageJson.stripes.type;
     ctx.moduleName = cwdPackageJson.name;
     ctx.isStripesModule = isStripesModule(cwdPackageJson.name);
-    ctx.isUiModule = isUiModule(ctx.type);
+    ctx.isUiModule = isUiModule(ctx.actsAs || ctx.type);
     return ctx;
   }
 

--- a/lib/commands/status.js
+++ b/lib/commands/status.js
@@ -17,7 +17,7 @@ function statusCommand(argv) {
   const context = argv.context;
   console.log('Status:');
   console.log(`  version: ${packageJson.version}`);
-  console.log(`  context: ${context.type}`);
+  console.log(`  context: ${context.actsAs || context.type}`);
   console.log(`  module: ${context.moduleName ? context.moduleName : ''}`);
   console.log(`  global cli: ${context.isGlobalCli}`);
   console.log(`  .stripesclirc: ${configPath || '(none found)'}`);

--- a/lib/environment/inventory.js
+++ b/lib/environment/inventory.js
@@ -13,6 +13,7 @@ const uiModules = [
   'ui-finance',
   'ui-inventory',
   'ui-licenses',
+  'ui-local-kb-admin',
   'ui-myprofile',
   'ui-orders',
   'ui-organization',

--- a/test/cli/context.spec.js
+++ b/test/cli/context.spec.js
@@ -4,10 +4,17 @@ const path = require('path');
 require('fast-xml-parser');  // included here to resolve a lazy-load issue of this module within tests
 const context = require('../../lib/cli/context');
 
-const createModule = (type) => ({
+const createModuleWithType = (type) => ({
   name: type === 'components' ? '@folio/stripes-components' : '@folio/ui-app',
   stripes: {
     type,
+  }
+});
+
+const createModuleWithActsAs = (actsAs) => ({
+  name: '@folio/ui-app',
+  stripes: {
+    actsAs,
   }
 });
 
@@ -18,7 +25,7 @@ describe('The CLI\'s getContext', function () {
 
   describe('parses stripes.type from package.json', function () {
     it('is ui module with type "app"', function () {
-      this.sandbox.stub(context, 'require').returns(createModule('app'));
+      this.sandbox.stub(context, 'require').returns(createModuleWithType('app'));
 
       const result = this.sut('someDir');
 
@@ -33,7 +40,7 @@ describe('The CLI\'s getContext', function () {
     });
 
     it('is ui module with type "settings"', function () {
-      this.sandbox.stub(context, 'require').returns(createModule('settings'));
+      this.sandbox.stub(context, 'require').returns(createModuleWithType('settings'));
 
       const result = this.sut('someDir');
 
@@ -48,7 +55,7 @@ describe('The CLI\'s getContext', function () {
     });
 
     it('is ui module with type "components"', function () {
-      this.sandbox.stub(context, 'require').returns(createModule('components'));
+      this.sandbox.stub(context, 'require').returns(createModuleWithType('components'));
 
       const result = this.sut('someDir');
 
@@ -60,6 +67,40 @@ describe('The CLI\'s getContext', function () {
         isPlatform: false,
         isBackendModule: false,
       });
+    });
+  });
+
+  describe('parses stripes.actsAs from package.json', function () {
+    it('is ui module with actsAs ["app", "settings"]', function () {
+      this.sandbox.stub(context, 'require').returns(createModuleWithActsAs(['app', 'settings']));
+
+      const result = this.sut('someDir');
+
+      expect(result).to.include({
+        isEmpty: false,
+        isStripesModule: false,
+        isUiModule: true,
+        isPlatform: false,
+        isBackendModule: false,
+      });
+
+      expect(result.actsAs).to.have.members(['app', 'settings']);
+    });
+
+    it('is ui module with actsAs ["settings"]', function () {
+      this.sandbox.stub(context, 'require').returns(createModuleWithActsAs(['settings']));
+
+      const result = this.sut('someDir');
+
+      expect(result).to.include({
+        isEmpty: false,
+        isStripesModule: false,
+        isUiModule: true,
+        isPlatform: false,
+        isBackendModule: false,
+      });
+
+      expect(result.actsAs).to.have.members(['settings']);
     });
   });
 


### PR DESCRIPTION
Various commands that need to be executed from within a UI module (eg, `stripes mod add`) don't work if the UI module uses `stripes.actsAs` instead of `stripes.type`.

I've attempted here to use `actsAs` first and fallback to `type`. No instances of `context.type` usage jumped out to me as being immediately rewritable since most of these checks do in fact nicely use `isUiModule`.

Added a couple of tests to ensure we're pulling the correct info.

Also added an entry to the `inventory` for the module that set me down this path.