### PR TITLE
depend on stripes-testing v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Change history for stripes-cli
 
-## IN PROGRESS
+## 1.30.0 (IN PROGRESS)
 
 * Added checking of `stripes.actsAs` when determining `isUiModule`, handles STCOR-148
+* stripes-testing `v1.6.0` includes `checkout`, `setCirculationRules` helpers.
 
 ## [1.12.1](https://github.com/folio-org/stripes-cli/tree/v1.12.1) (2019-06-11)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-cli",
-  "version": "1.12.1",
+  "version": "1.13.0",
   "description": "Stripes Command Line Interface",
   "repository": "https://github.com/folio-org/stripes-cli",
   "publishConfig": {
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@folio/stripes-core": "^2.17.1 || ^3.0.0",
-    "@folio/stripes-testing": "^1.5.0",
+    "@folio/stripes-testing": "^1.6.0",
     "babel-plugin-istanbul": "^4.1.6",
     "configstore": "^3.1.1",
     "debug": "^4.0.1",


### PR DESCRIPTION
stripes-testing `v1.6.0` includes `checkout`, `setCirculationRules`
helpers.