### PR TITLE
Stcli 130 remove yarn lock files on platform clean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Retrieving template files for creating UI Modules and setting up BigTest from https://github.com/folio-org/ui-app-template. Removed old template files from /resources directory.  STCLI-133
 * Add many additional apps/libraries, STCLI-142
+* New optional `platform clean` option `--removeLock` to delete `yarn.lock` file(s) after cleaning platform/workspace: STCLI-130
 
 ## [1.13.0](https://github.com/folio-org/stripes-cli/tree/v1.13.0) (2019-07-24)
 

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -1028,12 +1028,17 @@ $ stripes platform clean
 Option | Description | Type | Notes
 ---|---|---|---
 `--install` | Install dependencies after cleaning | boolean | default: false
+`--removeLock` | Remove yarn.lock file(s) after cleaning | boolean | default: false
 
 Examples:
 
 Clean and reinstall dependencies:
 ```
 $ stripes platform clean --install
+```
+Clean, remove yarn.lock file(s), then reinstall dependencies:
+```
+$ stripes platform clean --install --removeLock
 ```
 Clean only:
 ```

--- a/lib/commands/platform/clean.js
+++ b/lib/commands/platform/clean.js
@@ -36,7 +36,7 @@ function cleanCommand(argv) {
   dev.loadExistingModules();
   const moduleDirs = dev.getModulePaths();
 
-  console.log(`Cleaning ${moduleDirs.length} directory(s) ...`);
+  console.log(`Cleaning ${moduleDirs.length} directories ...`);
 
   if (argv.removeLock) {
     console.log(`Removing ${moduleDirs.length} yarn.lock file(s) ...`);
@@ -55,10 +55,10 @@ function cleanCommand(argv) {
     .then(() => {
       if (argv.install) {
         console.log('Installing dependencies ...');
-        dev.installDependencies();
+        return dev.installDependencies();
+      } else {
+        return Promise.resolve();
       }
-      
-      return Promise.resolve();
     })
     .then(() => {
       console.log('Done.');
@@ -84,7 +84,7 @@ module.exports = {
     });
     yargs
       .example('$0 platform clean --install', 'Clean and reinstall dependencies')
-      .example('$0 platform clean --removeLock', 'Clean and remove yarn.lock file')
+      .example('$0 platform clean --removeLock', 'Clean and remove yarn.lock file(s)')
       .example('$0 platform clean', 'Clean only');
     return yargs;
   },

--- a/lib/commands/platform/clean.js
+++ b/lib/commands/platform/clean.js
@@ -78,7 +78,7 @@ module.exports = {
       default: false,
     });
     yargs.option('removeLock', {
-      describe: 'Remove yarn.lock file after cleaning',
+      describe: 'Remove yarn.lock file(s) after cleaning',
       type: 'boolean',
       default: false,
     });

--- a/lib/commands/platform/clean.js
+++ b/lib/commands/platform/clean.js
@@ -6,9 +6,9 @@ const fs = importLazy('fs');
 const rimraf = importLazy('rimraf');
 const DevelopmentEnvironment = importLazy('../../environment/development');
 
-function cleanNodeModules(dir) {
+function removeFileOrFolder(dir, fileOrFolderName) {
   return new Promise((resolve) => {
-    const nodeModules = path.resolve(dir, 'node_modules');
+    const nodeModules = path.resolve(dir, fileOrFolderName);
     if (fs.existsSync(nodeModules)) {
       rimraf(nodeModules, {}, (err) => {
         if (err) {
@@ -36,21 +36,29 @@ function cleanCommand(argv) {
   dev.loadExistingModules();
   const moduleDirs = dev.getModulePaths();
 
-  console.log(`Cleaning ${moduleDirs.length} directories ...`);
+  console.log(`Cleaning ${moduleDirs.length} directory(s) ...`);
+
+  if (argv.removeLock) {
+    console.log(`Removing ${moduleDirs.length} yarn.lock file(s) ...`);
+  }
 
   const clean = [];
   moduleDirs.forEach((dir) => {
-    clean.push(cleanNodeModules(dir));
+    clean.push(removeFileOrFolder(dir, 'node_modules'));
+
+    if (argv.removeLock) {
+      clean.push(removeFileOrFolder(dir, 'yarn.lock'));
+    }
   });
 
   return Promise.all(clean)
     .then(() => {
       if (argv.install) {
         console.log('Installing dependencies ...');
-        return dev.installDependencies();
-      } else {
-        return Promise.resolve();
+        dev.installDependencies();
       }
+      
+      return Promise.resolve();
     })
     .then(() => {
       console.log('Done.');
@@ -69,8 +77,14 @@ module.exports = {
       type: 'boolean',
       default: false,
     });
+    yargs.option('removeLock', {
+      describe: 'Remove yarn.lock file after cleaning',
+      type: 'boolean',
+      default: false,
+    });
     yargs
       .example('$0 platform clean --install', 'Clean and reinstall dependencies')
+      .example('$0 platform clean --removeLock', 'Clean and remove yarn.lock file')
       .example('$0 platform clean', 'Clean only');
     return yargs;
   },


### PR DESCRIPTION
- Fulfills https://issues.folio.org/browse/STCLI-130
- Added optional param `--removeLock` to delete yarn.lock file(s) after cleaning and prior to re-install.