### PR TITLE
STCLI-143: bump up nyc version

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "mocha": "^5.2.0",
     "mocha-jenkins-reporter": "^0.4.1",
     "node-fetch-npm": "^2.0.2",
-    "nyc": "^12.0.2",
+    "nyc": "^14.1.1",
     "resolve-from": "^4.0.0",
     "resolve-pkg": "^1.0.0",
     "rimraf": "^2.6.2",


### PR DESCRIPTION
https://issues.folio.org/browse/STCLI-143

##Purpose
Package "nyc@^12.0.2" uses "mem@^1.1.1". In "mem" before version 4.0.0, there is a memory leak due to old results not being removed from the cache despite reaching maxAge. Bumping up the version of "nyc" package to 14 fixes this issue as it uses "mem@4.3.0"

