### PR TITLE
UIDEXP-8: Add ui-data-export module

### DIFF
--- a/lib/environment/inventory.js
+++ b/lib/environment/inventory.js
@@ -8,6 +8,7 @@ const uiModules = [
   'ui-checkout',
   'ui-circulation',
   'ui-data-import',
+  'ui-data-export',
   'ui-developer',
   'ui-eholdings',
   'ui-erm-usage',


### PR DESCRIPTION
## Purpose

Add [ui-data-export](https://github.com/folio-org/ui-data-export) module in the scope of the [UIDEXP-8](https://issues.folio.org/browse/UIDEXP-8).