### PR TITLE
UIDEXP-11: Add stripes-data-transfer-components module

### DIFF
--- a/lib/environment/inventory.js
+++ b/lib/environment/inventory.js
@@ -50,6 +50,7 @@ const stripesModules = [
   'stripes-connect',
   'stripes-core',
   'stripes-erm-components',
+  'stripes-data-transfer-components',
   'stripes-final-form',
   'stripes-form',
   'stripes-logger',


### PR DESCRIPTION
## Purpose

Add [stripes-data-transfer-components](https://github.com/folio-org/ui-data-export) module in the scope of the [UIDEXP-11](https://issues.folio.org/browse/UIDEXP-11).