### PR TITLE
Add default output path to build command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.15.0 (IN PROGRESS)
 
 * Support stripes-core `v4.0.0`.
+* Added default value of `./output` for `--output` flag used when running `build` command. Refs STCLI-95.
 
 ## [1.14.0](https://github.com/folio-org/stripes-cli/tree/v1.14.0) (2019-09-09)
 

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -220,7 +220,7 @@ Option | Description | Type | Notes
 `--maxChunks` | Limit the number of Webpack chunks in build output | number |
 `--minify` | Minify the bundle output | boolean | default: true
 `--okapi` | Specify an Okapi URL | string |
-`--output` | Directory to place build output | string |
+`--output` | Directory to place build output (if omitted, default value `./output` is used) | string |
 `--publicPath` | Specify the Webpack publicPath output option | string |
 `--sourcemap` | Include sourcemaps in build output | boolean |
 `--stripesConfig` | Stripes config JSON  | string | supports stdin

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -220,7 +220,7 @@ Option | Description | Type | Notes
 `--maxChunks` | Limit the number of Webpack chunks in build output | number |
 `--minify` | Minify the bundle output | boolean | default: true
 `--okapi` | Specify an Okapi URL | string |
-`--output` | Directory to place build output (if omitted, default value `./output` is used) | string |
+`--output` | Directory to place build output | string |
 `--publicPath` | Specify the Webpack publicPath output option | string |
 `--sourcemap` | Include sourcemaps in build output | boolean |
 `--stripesConfig` | Stripes config JSON  | string | supports stdin

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -1,6 +1,6 @@
 # Stripes CLI Commands
 
-Version 1.10.0
+Version 1.15.0
 
 This following command documentation is generated from the CLI's own built-in help.  Run any command with the `--help` option to view the latest help for your currently installed CLI.  To regenerate this file, run `yarn docs`.
 
@@ -220,7 +220,7 @@ Option | Description | Type | Notes
 `--maxChunks` | Limit the number of Webpack chunks in build output | number |
 `--minify` | Minify the bundle output | boolean | default: true
 `--okapi` | Specify an Okapi URL | string |
-`--output` | Directory to place build output | string |
+`--output` | Directory to place build output. If omitted, default value of "./output" is used. | string |
 `--publicPath` | Specify the Webpack publicPath output option | string |
 `--sourcemap` | Include sourcemaps in build output | boolean |
 `--stripesConfig` | Stripes config JSON  | string | supports stdin
@@ -1036,9 +1036,9 @@ Clean and reinstall dependencies:
 ```
 $ stripes platform clean --install
 ```
-Clean, remove yarn.lock file(s), then reinstall dependencies:
+Clean and remove yarn.lock file(s):
 ```
-$ stripes platform clean --install --removeLock
+$ stripes platform clean --removeLock
 ```
 Clean only:
 ```

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -497,9 +497,9 @@ Could be written as `stripes.config.json` in JSON format:
 Further, when using JSON format, the CLI also accepts this configuration piped via stdin.  Therefore, given the above configuration files exist, each of these commands would produce the same output:
 
 ```
-$ stripes build stripes.config.js --output ./bundle/path
-$ stripes build stripes.config.json --output ./bundle/path
-$ cat stripes.config.json | stripes build --output ./bundle/path
+$ stripes build stripes.config.js
+$ stripes build stripes.config.json
+$ cat stripes.config.json | stripes build
 ```
 
 The last example becomes useful when your Stripes configuration does not reside on disk and is instead emitted from another process.

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -7,8 +7,8 @@ const StripesPlatform = importLazy('../platform/stripes-platform');
 const { okapiOptions, stripesConfigFile, stripesConfigStdin, stripesConfigOptions, buildOptions } = importLazy('./common-options');
 const { processError, processStats, emitLintWarnings, limitChunks } = importLazy('../webpack-common');
 
-
-function buildCommand(argv) {
+// stripesPlatform and stripesCore are optional params primarily used as injection for unit tests
+function buildCommand(argv, stripesPlatform, stripesCore) {
   const context = argv.context;
   // Default build command to production env
   if (!process.env.NODE_ENV) {
@@ -24,7 +24,7 @@ function buildCommand(argv) {
     console.warn('Warning: Building a platform without a stripes configuration.  Did you forget to include "stripes.config.js"?');
   }
 
-  const platform = new StripesPlatform(argv.stripesConfig, context, argv);
+  const platform = stripesPlatform || new StripesPlatform(argv.stripesConfig, context, argv);
   const webpackOverrides = platform.getWebpackOverrides(context);
 
   if (argv.analyze) {
@@ -37,6 +37,8 @@ function buildCommand(argv) {
 
   if (argv.output) {
     argv.outputPath = argv.output;
+  } else {
+    argv.outputPath = './output';
   }
   if (argv.lint) {
     webpackOverrides.push(emitLintWarnings);
@@ -51,7 +53,7 @@ function buildCommand(argv) {
   // TODO: Check stripes-core location and aliases to warn if build is unsuitable for production.
 
   console.log('Building...');
-  const stripes = new StripesCore(context, platform.aliases);
+  const stripes = stripesCore || new StripesCore(context, platform.aliases);
   stripes.api.build(platform.getStripesConfig(), Object.assign({}, argv, { webpackOverrides }))
     .then(processStats)
     .catch(processError);
@@ -74,7 +76,7 @@ module.exports = {
         conflicts: 'output',
       })
       .option('output', {
-        describe: 'Directory to place build output',
+        describe: 'Directory to place build output. If omitted, default value of "./output" is used.',
         type: 'string',
       })
       .option('sourcemap', {

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -7,8 +7,15 @@ const StripesPlatform = importLazy('../platform/stripes-platform');
 const { okapiOptions, stripesConfigFile, stripesConfigStdin, stripesConfigOptions, buildOptions } = importLazy('./common-options');
 const { processError, processStats, emitLintWarnings, limitChunks } = importLazy('../webpack-common');
 
-// stripesPlatform and stripesCore are optional params primarily used as injection for unit tests
-function buildCommand(argv, stripesPlatform, stripesCore) {
+let _stripesPlatform, _stripesCore;
+
+// stripesPlatform and stripesCore overrides primarily used as injection for unit tests
+function stripesOverrides(stripesPlatform, stripesCore) {
+  _stripesPlatform = stripesPlatform;
+  _stripesCore = stripesCore;
+}
+
+function buildCommand(argv) {
   const context = argv.context;
   // Default build command to production env
   if (!process.env.NODE_ENV) {
@@ -24,7 +31,7 @@ function buildCommand(argv, stripesPlatform, stripesCore) {
     console.warn('Warning: Building a platform without a stripes configuration.  Did you forget to include "stripes.config.js"?');
   }
 
-  const platform = stripesPlatform || new StripesPlatform(argv.stripesConfig, context, argv);
+  const platform = _stripesPlatform || new StripesPlatform(argv.stripesConfig, context, argv);
   const webpackOverrides = platform.getWebpackOverrides(context);
 
   if (argv.analyze) {
@@ -53,7 +60,7 @@ function buildCommand(argv, stripesPlatform, stripesCore) {
   // TODO: Check stripes-core location and aliases to warn if build is unsuitable for production.
 
   console.log('Building...');
-  const stripes = stripesCore || new StripesCore(context, platform.aliases);
+  const stripes = _stripesCore || new StripesCore(context, platform.aliases);
   stripes.api.build(platform.getStripesConfig(), Object.assign({}, argv, { webpackOverrides }))
     .then(processStats)
     .catch(processError);
@@ -99,4 +106,5 @@ module.exports = {
       .example('$0 build --output ./output-dir', 'Build a single ui-module (from ui-module directory)');
   },
   handler: buildCommand,
+  stripesOverrides,
 };

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -7,7 +7,8 @@ const StripesPlatform = importLazy('../platform/stripes-platform');
 const { okapiOptions, stripesConfigFile, stripesConfigStdin, stripesConfigOptions, buildOptions } = importLazy('./common-options');
 const { processError, processStats, emitLintWarnings, limitChunks } = importLazy('../webpack-common');
 
-let _stripesPlatform, _stripesCore;
+let _stripesPlatform;
+let _stripesCore;
 
 // stripesPlatform and stripesCore overrides primarily used as injection for unit tests
 function stripesOverrides(stripesPlatform, stripesCore) {

--- a/test/commands/build.spec.js
+++ b/test/commands/build.spec.js
@@ -1,0 +1,63 @@
+const expect = require('chai').expect;
+
+const buildAppCommand = require('../../lib/commands/build');
+
+const packageJsonStub = {};
+const tenantConfig = {};
+
+function StripesModuleParserStub(name) {
+  this.packageJson = Object.assign({}, packageJsonStub, { name });
+}
+
+const stripesCoreStub = {
+  api: {
+    build: () => Promise.resolve({ hasErrors: () => {} }),
+    StripesModuleParser: StripesModuleParserStub,
+  }
+};
+
+const platformStub = {
+  getWebpackOverrides: () => [],
+  getStripesConfig: () => tenantConfig,
+  getStripesCore: () => stripesCoreStub,
+};
+
+describe('The app create command', function () {
+  beforeEach(function () {
+    this.argv = {
+      context: 'hello world',
+      desc: 'my first app',
+    };
+    this.argv.context = {
+      type: 'empty',
+      cwd: '/path/to/working/directory',
+      cliRoot: '/path/to/cliRoot',
+      isEmpty: true,
+    };
+
+    this.sut = buildAppCommand;
+    this.sandbox.spy(console, 'log');
+    this.sandbox.spy(buildAppCommand, 'handler');
+    this.sandbox.spy(stripesCoreStub.api, 'build');
+  });
+
+  it('calls "build app" handler with default folder when --output flag is omitted.', function (done) {
+    const expectedArgs = Object.assign({}, this.argv, { outputPath: './output', webpackOverrides: [] } );
+    this.sut.handler(this.argv, platformStub, stripesCoreStub);
+
+    expect(buildAppCommand.handler).to.have.been.calledOnce;
+    expect(stripesCoreStub.api.build).to.have.been.calledWith(tenantConfig, expectedArgs);
+    expect(console.log).to.have.been.calledWithMatch('Building...');
+    done();
+  });
+
+  it('calls "build app" handler with declared folder when --output flag is used.', function (done) {
+    const expectedArgs = Object.assign({}, this.argv, { outputPath: './custom-path', output: './custom-path', webpackOverrides: [] });
+    this.sut.handler(Object.assign({}, this.argv, { output: './custom-path' }), platformStub, stripesCoreStub);
+
+    expect(buildAppCommand.handler).to.have.been.calledOnce;
+    expect(stripesCoreStub.api.build).to.have.been.calledWith(tenantConfig, expectedArgs);
+    expect(console.log).to.have.been.calledWithMatch('Building...');
+    done();
+  });
+});

--- a/test/commands/build.spec.js
+++ b/test/commands/build.spec.js
@@ -41,7 +41,7 @@ describe('The app create command', function () {
     this.sandbox.spy(stripesCoreStub.api, 'build');
   });
 
-  it('calls "build app" handler with default folder when --output flag is omitted.', function (done) {
+  it('calls "build app" handler with default output folder when --output flag is omitted.', function (done) {
     const expectedArgs = Object.assign({}, this.argv, { outputPath: './output', webpackOverrides: [] });
     this.sut.handler(this.argv, platformStub, stripesCoreStub);
 
@@ -51,7 +51,7 @@ describe('The app create command', function () {
     done();
   });
 
-  it('calls "build app" handler with declared folder when --output flag is used.', function (done) {
+  it('calls "build app" handler with specified output folder when --output flag is used.', function (done) {
     const expectedArgs = Object.assign({}, this.argv, { outputPath: './custom-path', output: './custom-path', webpackOverrides: [] });
     this.sut.handler(Object.assign({}, this.argv, { output: './custom-path' }), platformStub, stripesCoreStub);
 

--- a/test/commands/build.spec.js
+++ b/test/commands/build.spec.js
@@ -42,7 +42,7 @@ describe('The app create command', function () {
   });
 
   it('calls "build app" handler with default folder when --output flag is omitted.', function (done) {
-    const expectedArgs = Object.assign({}, this.argv, { outputPath: './output', webpackOverrides: [] } );
+    const expectedArgs = Object.assign({}, this.argv, { outputPath: './output', webpackOverrides: [] });
     this.sut.handler(this.argv, platformStub, stripesCoreStub);
 
     expect(buildAppCommand.handler).to.have.been.calledOnce;

--- a/test/commands/build.spec.js
+++ b/test/commands/build.spec.js
@@ -43,7 +43,8 @@ describe('The app create command', function () {
 
   it('calls "build app" handler with default output folder when --output flag is omitted.', function (done) {
     const expectedArgs = Object.assign({}, this.argv, { outputPath: './output', webpackOverrides: [] });
-    this.sut.handler(this.argv, platformStub, stripesCoreStub);
+    this.sut.stripesOverrides(platformStub, stripesCoreStub);
+    this.sut.handler(this.argv);
 
     expect(buildAppCommand.handler).to.have.been.calledOnce;
     expect(stripesCoreStub.api.build).to.have.been.calledWith(tenantConfig, expectedArgs);
@@ -53,7 +54,8 @@ describe('The app create command', function () {
 
   it('calls "build app" handler with specified output folder when --output flag is used.', function (done) {
     const expectedArgs = Object.assign({}, this.argv, { outputPath: './custom-path', output: './custom-path', webpackOverrides: [] });
-    this.sut.handler(Object.assign({}, this.argv, { output: './custom-path' }), platformStub, stripesCoreStub);
+    this.sut.stripesOverrides(platformStub, stripesCoreStub);
+    this.sut.handler(Object.assign({}, this.argv, { output: './custom-path' }));
 
     expect(buildAppCommand.handler).to.have.been.calledOnce;
     expect(stripesCoreStub.api.build).to.have.been.calledWith(tenantConfig, expectedArgs);


### PR DESCRIPTION
- Fulfills [STCLI-95](https://issues.folio.org/browse/STCLI-95).
- Updated documentation for `--output` usage and default value when omitted.
- Updated`commands/build.js` to support injecting `stripesPlatform` and `stripesCore` so they can be mocked. 
- Added unit tests for new usage.