### PR TITLE
Extend 'stripes mod generate --full --strict' to support optionalOkapiInterfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Support stripes-core `v4.0.0`.
 * Use stripes-testing `v2.0.0`
+* Support optional dependencies in UI modules. Related to OKAPI-509.
 
 ## [1.14.0](https://github.com/folio-org/stripes-cli/tree/v1.14.0) (2019-09-09)
 

--- a/lib/cli/generate-module-descriptor.js
+++ b/lib/cli/generate-module-descriptor.js
@@ -2,14 +2,18 @@
 // $ node ../stripes-core/util/package2md.js package.json > MD.json
 module.exports = function generateModuleDescriptor(packageJson, isStrict) {
   const stripes = packageJson.stripes || {};
-  const interfaces = stripes.okapiInterfaces || [];
   const moduleDescriptor = {
     id: `${packageJson.name.replace(/^@/, '').replace('/', '_')}-${packageJson.version}`,
     name: packageJson.description,
     permissionSets: stripes.permissionSets || [],
   };
   if (isStrict) {
-    moduleDescriptor.requires = Object.keys(interfaces).map(key => ({ id: key, version: interfaces[key] }));
+    const interfaces = stripes.okapiInterfaces || [];
+    const optional = stripes.optionalOkapiInterfaces || [];
+    moduleDescriptor.requires = [].concat(
+      Object.keys(interfaces).map(key => ({ id: key, version: interfaces[key] })),
+      Object.keys(optional).map(key => ({ id: key, version: optional[key], optional: true })),
+    );
   }
   return moduleDescriptor;
 };

--- a/test/okapi/descriptor-service.spec.js
+++ b/test/okapi/descriptor-service.spec.js
@@ -27,6 +27,9 @@ const packageJsonStub = {
     okapiInterfaces: {
       backend: '2.0',
     },
+    optionalOkapiInterfaces: {
+      backend2: '3.1',
+    },
     permissionSets: [
       {
         permissionName: 'module.example.enabled',
@@ -120,6 +123,11 @@ describe('The descriptor-service', function () {
           {
             id: 'backend',
             version: '2.0'
+          },
+          {
+            id: 'backend2',
+            version: '3.1',
+            optional: true
           }
         ]
       }];
@@ -173,6 +181,11 @@ describe('The descriptor-service', function () {
             {
               id: 'backend',
               version: '2.0'
+            },
+            {
+              id: 'backend2',
+              version: '3.1',
+              optional: true
             }
           ]
         };


### PR DESCRIPTION
Includes test coverage.

This is the second and last Stripes parts of OKAPI-509, and allows a UI module to declare optional dependencies on Okapi interfaces.

(The first Stripes part was an analogous change in the deprecated-but-still-used package2md script: see https://github.com/folio-org/stripes-core/commit/358342c2c2e63bcceaeae5b8c5b68a850d2afdcd)