### PR TITLE
bump minor to 1.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-cli",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "description": "Stripes Command Line Interface",
   "repository": "https://github.com/folio-org/stripes-cli",
   "publishConfig": {


### PR DESCRIPTION
We added support for `stripes-core` `v5`; we need to allow UI apps to
specify that.