### PR TITLE
Releasing 1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for stripes-cli
 
-## [1.16.1] IN PROGRESS
+## [1.17.0](https://github.com/folio-org/stripes-cli/tree/v1.17.0) (2020-06-19)
 
 * Introduced new command `stripes inventory --fetch` to update module list for `stripes workspace` command. Refs STCLI-122.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-cli",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Stripes Command Line Interface",
   "repository": "https://github.com/folio-org/stripes-cli",
   "publishConfig": {


### PR DESCRIPTION
Includes new command `stripes inventory --fetch` to update module list for `stripes workspace` command. Refs STCLI-122.