### PR TITLE
okapi-client logs as curl commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.18.0 (IN PROGRESS)
 
 * Support `stripes-core` `v6.0.0`.
+* okapi-client logs as curl commands, including headers and body, because that's super handy.
 
 ## [1.17.0](https://github.com/folio-org/stripes-cli/tree/v1.17.0) (2020-06-19)
 

--- a/lib/okapi/okapi-client.js
+++ b/lib/okapi/okapi-client.js
@@ -16,21 +16,11 @@ function ensureOk(response) {
 }
 
 function optionsHeaders(options) {
-  let h = '';
-  if (options.headers) {
-    h = Object.entries(options.headers).map(([k, v]) => `-H '${k}: ${v}'`).join(' ');
-  }
-
-  return h;
+  return Object.entries(options.headers || {}).map(([k, v]) => `-H '${k}: ${v}'`).join(' ');
 }
 
 function optionsBody(options) {
-  let b = '';
-  if (options.body) {
-    b = `-d ${JSON.stringify(options.body)}`;
-  }
-
-  return b;
+  return options.body ? `-d ${JSON.stringify(options.body)}` : '';
 }
 
 // Wraps fetch to capture request/response for logging

--- a/lib/okapi/okapi-client.js
+++ b/lib/okapi/okapi-client.js
@@ -15,9 +15,27 @@ function ensureOk(response) {
   });
 }
 
+function optionsHeaders(options) {
+  let h = '';
+  if (options.headers) {
+    h = Object.entries(options.headers).map(([k, v]) => `-H '${k}: ${v}'`).join(' ');
+  }
+
+  return h;
+}
+
+function optionsBody(options) {
+  let b = '';
+  if (options.body) {
+    b = `-d ${JSON.stringify(options.body)}`;
+  }
+
+  return b;
+}
+
 // Wraps fetch to capture request/response for logging
 function okapiFetch(resource, options) {
-  logger.log(`---> ${options.method} ${resource}`);
+  logger.log(`---> curl -X${options.method} ${optionsHeaders(options)} ${resource} ${optionsBody(options)}`);
   return fetch(resource, options).then(ensureOk);
 }
 


### PR DESCRIPTION
Alter the logging output from okapi-client, which is present when
invoked with `DEBUG=stripes-cli:okapi`, so it includes HTTP request
headers and body in the format of `curl` commands. Having this
`under-the-hood`/`behind-the-curtain` view could make debugging these
commands much easier.