### PR TITLE
Add handler to ui module list

### DIFF
--- a/lib/cli/context.js
+++ b/lib/cli/context.js
@@ -22,7 +22,7 @@ function isGlobalYarn() {
 }
 
 function isUiModule(actsAs) {
-  const uiModuleTypes = ['app', 'settings', 'plugin'];
+  const uiModuleTypes = ['app', 'settings', 'plugin', 'handler'];
 
   // Backwards compatibility for modules using the `type` string property instead
   // of the new `actsAs` array.


### PR DESCRIPTION
@K-Felk is currently running into an issue when trying to run tests with a `handler` module. This PR  adds a `handler` type to the list of ui modules so: https://github.com/folio-org/stripes-cli/blob/160ab87f34b5caef7aba257d158e6a6f00a1ee50/lib/commands/test/karma.js#L17 doesn't complain about it.
