### PR TITLE
Updating to karma 4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-cli
 
+## 1.20.0 (IN PROGRESS)
+
+* Upgrade karma to `v4.4` which removes `core-js` dependency to clean up a warning which displays when compiling any app.
+
 ## [1.19.0](https://github.com/folio-org/stripes-cli/tree/v1.19.0) (2020-10-14)
 
 * Support `stripes-core` `v6.0.0`.

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "istanbul-reports": "^2.2.6",
     "just-kebab-case": "^1.0.0",
     "just-pascal-case": "^1.0.0",
-    "karma": "^3.0.0",
+    "karma": "^4.4.0",
     "karma-browserstack-launcher": "^1.3.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-coverage-istanbul-reporter": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-cli",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Stripes Command Line Interface",
   "repository": "https://github.com/folio-org/stripes-cli",
   "publishConfig": {


### PR DESCRIPTION
Fulfills [STCLI-146](https://issues.folio.org/browse/STCLI-146)

Noting that only breaking change is deprecating Node 6, which we don't rely on (we are generally on 8 or higher): https://github.com/karma-runner/karma/releases/tag/v4.0.0

Using 4.4, since that also quietly removed the `core-js` dependency: https://github.com/karma-runner/karma/releases/tag/v4.4.0