### PR TITLE
Webpack DLL Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.20.0](https://github.com/folio-org/stripes-cli/tree/v1.20.0) (2020-10-30)
 
 * Upgrade karma to `v4.4` which removes `core-js` dependency to clean up a warning which displays when compiling any app.
+* Add support for building and consuming Webpack DLLs. Refs STCLI-154.
 
 ## [1.19.0](https://github.com/folio-org/stripes-cli/tree/v1.19.0) (2020-10-14)
 

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -225,10 +225,11 @@ Option | Description | Type | Notes
 `--okapi` | Specify an Okapi URL | string |
 `--output` | Directory to place build output. If omitted, default value of "./output" is used. | string |
 `--publicPath` | Specify the Webpack publicPath output option | string |
+`--skipStripesBuild` | Bypass Stripes-specific steps in build (useful when building third-party Webpack DLLs). | boolean |
 `--sourcemap` | Include sourcemaps in build output | boolean |
 `--stripesConfig` | Stripes config JSON  | string | supports stdin
 `--tenant` | Specify a tenant ID | string |
-`--useDll` | List of DLLs (comma-separated) to include in build. | string |
+`--useDll` | List of DLL manifest files (comma-separated) to include in build. | string |
 
 Examples:
 
@@ -246,11 +247,11 @@ $ stripes build --output ./output-dir
 ```
 Builds a Webpack DLL called vendor with react and react-dom:
 ```
-$ stripes build --createDll react,react-dom --dllName vendor
+$ stripes build --createDll react,react-dom --dllName vendor --skipStripesBuild
 ```
 Build using vendor and stripes DLLs:
 ```
-$ stripes build stripes.config.js --useDll vendor,stripes
+$ stripes build stripes.config.js --useDll ./path/vendor.json,./path/stripes.json
 ```
 
 ## `inventory` command

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -1,5 +1,7 @@
 # Stripes CLI Commands
 
+Version 1.20.0
+
 This following command documentation is generated from the CLI's own built-in help.  Run any command with the `--help` option to view the latest help for your currently installed CLI.  To regenerate this file, run `yarn docs`.
 
 > Note: Commands labeled "(work in progress)" are incomplete or experimental and subject to change.
@@ -212,7 +214,9 @@ Positional | Description | Type | Notes
 Option | Description | Type | Notes
 ---|---|---|---
 `--analyze` | Run the Webpack Bundle Analyzer after build (launches in browser) | boolean |
+`--createDll` | List of dependencies (comma-separated) to build into a Webpack DLL. | string |
 `--devtool` | Specify the Webpack devtool for generating source maps | string |
+`--dllName` | Name of Webpack DLL to create. | string |
 `--hasAllPerms` | Set "hasAllPerms" in Stripes config | boolean |
 `--languages` | Languages to include in tenant build | array |
 `--lint` | Show eslint warnings with build | boolean |
@@ -224,6 +228,7 @@ Option | Description | Type | Notes
 `--sourcemap` | Include sourcemaps in build output | boolean |
 `--stripesConfig` | Stripes config JSON  | string | supports stdin
 `--tenant` | Specify a tenant ID | string |
+`--useDll` | List of DLLs (comma-separated) to include in build. | string |
 
 Examples:
 
@@ -238,6 +243,14 @@ $ stripes build stripes.config.js ./output-dir --no-minify
 Build a single ui-module (from ui-module directory):
 ```
 $ stripes build --output ./output-dir
+```
+Builds a Webpack DLL called vendor with react and react-dom:
+```
+$ stripes build --createDll react,react-dom --dllName vendor
+```
+Build using vendor and stripes DLLs:
+```
+$ stripes build stripes.config.js --useDll vendor,stripes
 ```
 
 ## `inventory` command
@@ -1105,6 +1118,7 @@ Positional | Description | Type | Notes
 Option | Description | Type | Notes
 ---|---|---|---
 `--cache` | Use HardSourceWebpackPlugin cache | boolean |
+`--coverage` | Enable coverage generation | boolean |
 `--devtool` | Specify the Webpack devtool for generating source maps | string |
 `--existing-build` | Serve an existing build from the supplied directory | string |
 `--hasAllPerms` | Set "hasAllPerms" in Stripes config | boolean |
@@ -1188,7 +1202,7 @@ Option | Description | Type | Notes
 
 Examples:
 
-Serve app and run it's demo.js Nightmare tests:
+Serve app and run its demo.js Nightmare tests:
 ```
 $ stripes test nightmare --run=demo
 ```
@@ -1300,7 +1314,7 @@ Option | Description | Type | Notes
 `--default.tenant` | Default tenant for CLI config | string | default: "diku"
 `--dir` | Directory to create | string | default: "stripes"
 `--install` | Install dependencies | boolean | default: true
-`--modules` | Stripes modules to include. Run `stripes workspace --modules --fetch` to update list. | array |
+`--modules` | Stripes modules to include | array |
 
 Examples:
 

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -37,6 +37,7 @@ Note: When serving or building an existing app module that has dependencies on u
 * [Generating a production build](#generating-a-production-build)
     * [Analyzing bundle output](#analyzing-bundle-output)
     * [Reducing build output](#reducing-build-output)
+    * [Using Webpack DLL](#using-webpack-dll)
 * [Viewing diagnostic output](#viewing-diagnostic-output)
     * [Observing Okapi requests](#observing-okapi-requests)
 
@@ -649,6 +650,22 @@ Filtering languages can be done with the CLI by specifying the `languages` optio
 ```
 $ stripes build stripes.config.js --languages en es
 ```
+
+### Using Webpack DLL
+
+A technique you can use to pre-build dependencies that change less frequently so that subsequent builds can be more focused in what code needs to be transpiled and will therefore run more quickly. For more information see: [DllPlugin documentation](https://webpack.js.org/plugins/dll-plugin/).
+
+For example, you could choose to create a re-usable DLL for third-party dependencies and call it "vendor":
+```
+$ stripes build --createDll react,react-dom,react-router --dllName vendor
+```
+
+To then use that DLL in the final bundle:
+```
+$ stripes build --useDll vendor
+```
+
+The benefit is that if you make changes to your code, you only need to re-run the final bundle command above which bypasses the need to re-bundle the third-party dependencies, which reduces the build time. Note that in this case if you update the version of a third-party dependency, you will then need to run both commands for the change to affect the final bundle.
 
 ## Viewing diagnostic output
 

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -655,9 +655,9 @@ $ stripes build stripes.config.js --languages en es
 
 A technique you can use to pre-build dependencies that change less frequently so that subsequent builds can be more focused in what code needs to be transpiled and will therefore run more quickly. For more information see: [DllPlugin documentation](https://webpack.js.org/plugins/dll-plugin/).
 
-For example, you could choose to create a re-usable DLL for third-party dependencies and call it "vendor":
+For example, you could choose to create a re-usable DLL for third-party dependencies and call it "vendor" (note that using the flag `--skipStripesBuild` is appropriate here as it will exclude Stripes-specific steps during the build. It should not be used when building a Stripes DLL):
 ```
-$ stripes build --createDll react,react-dom,react-router --dllName vendor
+$ stripes build --createDll react,react-dom,react-router --dllName vendor --skipStripesBuild
 ```
 
 To then use that DLL in the final bundle, point to the manifest JSON file:

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -660,9 +660,9 @@ For example, you could choose to create a re-usable DLL for third-party dependen
 $ stripes build --createDll react,react-dom,react-router --dllName vendor
 ```
 
-To then use that DLL in the final bundle:
+To then use that DLL in the final bundle, point to the manifest JSON file:
 ```
-$ stripes build --useDll vendor
+$ stripes build --useDll ./path/to/dll/vendor.json
 ```
 
 The benefit is that if you make changes to your code, you only need to re-run the final bundle command above which bypasses the need to re-bundle the third-party dependencies, which reduces the build time. Note that in this case if you update the version of a third-party dependency, you will then need to run both commands for the change to affect the final bundle.

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -62,7 +62,7 @@ function buildCommand(argv) {
 
   console.log('Building...');
   const stripes = _stripesCore || new StripesCore(context, platform.aliases);
-  stripes.api.build(!argv.createDll ? platform.getStripesConfig() : null, Object.assign({}, argv, { webpackOverrides }))
+  stripes.api.build(!argv.skipStripesBuild ? platform.getStripesConfig() : null, Object.assign({}, argv, { webpackOverrides }))
     .then(processStats)
     .catch(processError);
 }
@@ -84,6 +84,10 @@ module.exports = {
       .option('dllName', {
         describe: 'Name of Webpack DLL to create.',
         type: 'string'
+      })
+      .option('skipStripesBuild', {
+        describe: 'Bypass Stripes-specific steps in build (useful when building third-party Webpack DLLs).',
+        type: 'boolean'
       })
       .option('useDll', {
         describe: 'List of DLL manifest files (comma-separated) to include in build.',
@@ -117,7 +121,7 @@ module.exports = {
       .example('$0 build stripes.config.js ./output-dir', 'Build a platform (from platform directory)')
       .example('$0 build stripes.config.js ./output-dir --no-minify', 'Build a platform without minification of the bundle')
       .example('$0 build --output ./output-dir', 'Build a single ui-module (from ui-module directory)')
-      .example('$0 build --createDll react,react-dom --dllName vendor', 'Builds a Webpack DLL called vendor with react and react-dom')
+      .example('$0 build --createDll react,react-dom --dllName vendor --skipStripesBuild', 'Builds a Webpack DLL called vendor with react and react-dom')
       .example('$0 build stripes.config.js --useDll ./path/vendor.json,./path/stripes.json', 'Build using vendor and stripes DLLs');
   },
   handler: buildCommand,

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -86,7 +86,7 @@ module.exports = {
         type: 'string'
       })
       .option('useDll', {
-        describe: 'List of DLLs (comma-separated) to include in build.',
+        describe: 'List of DLL manifest files (comma-separated) to include in build.',
         type: 'string'
       })
       // A positional in order to remain backwards compatible with stripes-core
@@ -118,7 +118,7 @@ module.exports = {
       .example('$0 build stripes.config.js ./output-dir --no-minify', 'Build a platform without minification of the bundle')
       .example('$0 build --output ./output-dir', 'Build a single ui-module (from ui-module directory)')
       .example('$0 build --createDll react,react-dom --dllName vendor', 'Builds a Webpack DLL called vendor with react and react-dom')
-      .example('$0 build stripes.config.js --useDll vendor,stripes', 'Build using vendor and stripes DLLs');
+      .example('$0 build stripes.config.js --useDll ./path/vendor.json,./path/stripes.json', 'Build using vendor and stripes DLLs');
   },
   handler: buildCommand,
   stripesOverrides,

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -79,15 +79,20 @@ module.exports = {
       .positional('configFile', stripesConfigFile.configFile)
       .option('createDll', {
         describe: 'List of dependencies (comma-separated) to build into a Webpack DLL.',
-        type: 'string'
+        type: 'string',
+        implies: 'dllName',
+        requiresArg: true
       })
       .option('dllName', {
         describe: 'Name of Webpack DLL to create.',
-        type: 'string'
+        type: 'string',
+        implies: 'createDll',
+        requiresArg: true
       })
       .option('skipStripesBuild', {
         describe: 'Bypass Stripes-specific steps in build (useful when building third-party Webpack DLLs).',
-        type: 'boolean'
+        type: 'boolean',
+        default: false
       })
       .option('useDll', {
         describe: 'List of DLL manifest files (comma-separated) to include in build.',

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -28,7 +28,7 @@ function buildCommand(argv) {
     return;
   }
 
-  if (context.isPlatform && !argv.stripesConfig) {
+  if (context.isPlatform && !argv.stripesConfig && !argv.createDll) {
     console.warn('Warning: Building a platform without a stripes configuration.  Did you forget to include "stripes.config.js"?');
   }
 
@@ -78,7 +78,7 @@ module.exports = {
       ])
       .positional('configFile', stripesConfigFile.configFile)
       .option('createDll', {
-        describe: 'Builds a list of dependencies into a Webpack DLL.',
+        describe: 'List of dependencies (comma-separated) to build into a Webpack DLL.',
         type: 'string'
       })
       .option('dllName', {
@@ -86,7 +86,7 @@ module.exports = {
         type: 'string'
       })
       .option('useDll', {
-        describe: 'List of DLLs to include in build.',
+        describe: 'List of DLLs (comma-separated) to include in build.',
         type: 'string'
       })
       // A positional in order to remain backwards compatible with stripes-core
@@ -116,7 +116,9 @@ module.exports = {
       .options(Object.assign({}, okapiOptions, stripesConfigStdin, stripesConfigOptions, buildOptions))
       .example('$0 build stripes.config.js ./output-dir', 'Build a platform (from platform directory)')
       .example('$0 build stripes.config.js ./output-dir --no-minify', 'Build a platform without minification of the bundle')
-      .example('$0 build --output ./output-dir', 'Build a single ui-module (from ui-module directory)');
+      .example('$0 build --output ./output-dir', 'Build a single ui-module (from ui-module directory)')
+      .example('$0 build --createDll react,react-dom --dllName vendor', 'Builds a Webpack DLL called vendor with react and react-dom')
+      .example('$0 build stripes.config.js --useDll vendor,stripes', 'Build using vendor and stripes DLLs');
   },
   handler: buildCommand,
   stripesOverrides,

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -1,7 +1,5 @@
 const importLazy = require('import-lazy')(require);
 
-const webpack = require('webpack');
-const path = require('path');
 const { contextMiddleware } = importLazy('../cli/context-middleware');
 const { stripesConfigMiddleware } = importLazy('../cli/stripes-config-middleware');
 const StripesCore = importLazy('../cli/stripes-core');
@@ -49,30 +47,6 @@ function buildCommand(argv) {
     argv.outputPath = argv.output;
   } else {
     argv.outputPath = './output';
-  }
-  if (argv.createDll && argv.dllName) {
-    webpackOverrides.push((config) => {
-      config.entry[argv.dllName] = argv.createDll.split(',');
-      config.output.library = '[name]';
-      config.output.filename = '[name].[hash].js';
-      config.plugins.push(new webpack.DllPlugin({
-        name: '[name]',
-        path: path.join(argv.outputPath, '[name]-manifest.json'),
-      }));
-      return config;
-    });
-  }
-  if (argv.useDll) {
-    webpackOverrides.push((config) => {
-      config.dependencies = argv.useDll.split(',');
-      for (let dependency in config.dependencies) {
-        config.plugins.push(new webpack.DllReferencePlugin({
-          context: argv.outputPath,
-          manifest: require(path.join(argv.outputPath, `${dependency}-manifest.json`))
-        }));
-      }
-      return config;
-    });
   }
   if (argv.lint) {
     webpackOverrides.push(emitLintWarnings);

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -1,5 +1,7 @@
 const importLazy = require('import-lazy')(require);
 
+const webpack = require('webpack');
+const path = require('path');
 const { contextMiddleware } = importLazy('../cli/context-middleware');
 const { stripesConfigMiddleware } = importLazy('../cli/stripes-config-middleware');
 const StripesCore = importLazy('../cli/stripes-core');
@@ -48,6 +50,30 @@ function buildCommand(argv) {
   } else {
     argv.outputPath = './output';
   }
+  if (argv.createDll && argv.dllName) {
+    webpackOverrides.push((config) => {
+      config.entry[argv.dllName] = argv.createDll.split(',');
+      config.output.library = '[name]';
+      config.output.filename = '[name].[hash].js';
+      config.plugins.push(new webpack.DllPlugin({
+        name: '[name]',
+        path: path.join(argv.outputPath, '[name]-manifest.json'),
+      }));
+      return config;
+    });
+  }
+  if (argv.useDll) {
+    webpackOverrides.push((config) => {
+      config.dependencies = argv.useDll.split(',');
+      for (let dependency in config.dependencies) {
+        config.plugins.push(new webpack.DllReferencePlugin({
+          context: argv.outputPath,
+          manifest: require(path.join(argv.outputPath, `${dependency}-manifest.json`))
+        }));
+      }
+      return config;
+    });
+  }
   if (argv.lint) {
     webpackOverrides.push(emitLintWarnings);
   }
@@ -62,7 +88,7 @@ function buildCommand(argv) {
 
   console.log('Building...');
   const stripes = _stripesCore || new StripesCore(context, platform.aliases);
-  stripes.api.build(platform.getStripesConfig(), Object.assign({}, argv, { webpackOverrides }))
+  stripes.api.build(!argv.createDll ? platform.getStripesConfig() : null, Object.assign({}, argv, { webpackOverrides }))
     .then(processStats)
     .catch(processError);
 }
@@ -77,6 +103,18 @@ module.exports = {
         stripesConfigMiddleware(),
       ])
       .positional('configFile', stripesConfigFile.configFile)
+      .option('createDll', {
+        describe: 'Builds a list of dependencies into a Webpack DLL.',
+        type: 'string'
+      })
+      .option('dllName', {
+        describe: 'Name of Webpack DLL to create.',
+        type: 'string'
+      })
+      .option('useDll', {
+        describe: 'List of DLLs to include in build.',
+        type: 'string'
+      })
       // A positional in order to remain backwards compatible with stripes-core
       .positional('outputPath', {
         describe: 'Directory to place build output',


### PR DESCRIPTION
- Add support for building and consuming Webpack DLLs. Refs [STCLI-154](https://issues.folio.org/browse/STCLI-154).
- Updated documentation.
- See Stripes Core PR here: https://github.com/folio-org/stripes-core/pull/945