### PR TITLE
support stripes-core v7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-cli
 
+## 1.21.0 IN PROGRESS
+
+* Support `stripes-core` `v7.0.0`.
+
 ## [1.20.0](https://github.com/folio-org/stripes-cli/tree/v1.20.0) (2020-10-30)
 
 * Upgrade karma to `v4.4` which removes `core-js` dependency to clean up a warning which displays when compiling any app.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ buildNPM {
   publishModDescriptor = 'no'
   runLint = 'yes'
   runTest = 'yes'
-  runSonarqube = true
+  runSonarqube = false
   runScripts = [
    ['test:coverage':'']
   ]

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "docs": "node ./lib/doc/generator"
   },
   "dependencies": {
-    "@folio/stripes-core": "^2.17.1 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+    "@folio/stripes-core": "^2.17.1 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
     "@folio/stripes-testing": "^2.0.0",
     "@octokit/rest": "^17.1.4",
     "babel-plugin-istanbul": "^4.1.6",


### PR DESCRIPTION
Include support for `@folio/stripes-core` `7.0.0`.