### PR TITLE
STRIPES-730: Break up stripes-cli and stripes-core

### DIFF
--- a/lib/cli/stripes-core.js
+++ b/lib/cli/stripes-core.js
@@ -10,7 +10,7 @@ const getStripesWebpackConfig = require('../test/webpack-config');
 module.exports = class StripesCore {
   constructor(context, aliases) {
     this.context = context;
-    this.coreAlias = aliases['@folio/stripes-core'];
+    this.coreAlias = aliases['@folio/stripes-webpack'];
     this.corePath = this.getCorePath();
   }
 
@@ -42,25 +42,25 @@ module.exports = class StripesCore {
     // If we have an alias, consider that first
     if (this.coreAlias) {
       found = this.coreAlias;
-      logger.log(`using stripes-core [alias]: ${found}`);
+      logger.log(`using stripes-webpack [alias]: ${found}`);
       return found;
     }
 
     for (let i = 0; i < tryPaths.length; i += 1) {
-      found = resolvePkg('@folio/stripes-core', { cwd: tryPaths[i] });
+      found = resolvePkg('@folio/stripes-webpack', { cwd: tryPaths[i] });
       if (found) { break; }
     }
     if (!found) {
-      throw new Error('Unable to locate stripes-core path.', tryPaths);
+      throw new Error('Unable to locate stripes-webpack path.', tryPaths);
     }
-    logger.log(`using stripes-core: ${found}`);
+    logger.log(`using stripes-webpack: ${found}`);
     return found;
   }
 
   getCoreModulePath(moduleId) {
     const coreModulePath = (this.corePath === this.coreAlias)
       ? path.join(this.corePath, moduleId)
-      : resolveFrom(this.corePath, `@folio/stripes-core/${moduleId}`);
+      : resolveFrom(this.corePath, `@folio/stripes-webpack/${moduleId}`);
     return coreModulePath;
   }
 

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "docs": "node ./lib/doc/generator"
   },
   "dependencies": {
-    "@folio/stripes-core": "^2.17.1 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
     "@folio/stripes-testing": "^2.0.0",
+    "@folio/stripes-webpack": "^1.0.0",
     "@octokit/rest": "^17.1.4",
     "babel-plugin-istanbul": "^4.1.6",
     "configstore": "^3.1.1",


### PR DESCRIPTION
https://issues.folio.org/browse/STRIPES-730

This is an attempt to break up a dependency on stripes-core by introducing [stripes-webpack](https://github.com/folio-org/stripes-webpack).

There is a corresponding PR in stripes-core related to this work:

https://github.com/folio-org/stripes-core/pull/1003

This change looked pretty straightforward (at least from the stripes-cli point of view) but perhaps I'm still missing something here. If this looks good I think we should probably rename `StripesCore` class to something else. 