### PR TITLE
STCLI-167: Use stripes-webpack instead of stripes-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for stripes-cli
 
-## 1.21.0 IN PROGRESS
+## 2.0.0 IN PROGRESS
 
 * Support `stripes-core` `v7.0.0`.
 * Serve static pages with `express` instead of `http-server`. Refs STCLI-147.

--- a/lib/cli/stripes-core.js
+++ b/lib/cli/stripes-core.js
@@ -10,7 +10,7 @@ const getStripesWebpackConfig = require('../test/webpack-config');
 module.exports = class StripesCore {
   constructor(context, aliases) {
     this.context = context;
-    this.coreAlias = aliases['@folio/stripes-core'];
+    this.coreAlias = aliases['@folio/stripes-webpack'];
     this.corePath = this.getCorePath();
   }
 
@@ -42,25 +42,25 @@ module.exports = class StripesCore {
     // If we have an alias, consider that first
     if (this.coreAlias) {
       found = this.coreAlias;
-      logger.log(`using stripes-core [alias]: ${found}`);
+      logger.log(`using stripes-webpack [alias]: ${found}`);
       return found;
     }
 
     for (let i = 0; i < tryPaths.length; i += 1) {
-      found = resolvePkg('@folio/stripes-core', { cwd: tryPaths[i] });
+      found = resolvePkg('@folio/stripes-webpack', { cwd: tryPaths[i] });
       if (found) { break; }
     }
     if (!found) {
-      throw new Error('Unable to locate stripes-core path.', tryPaths);
+      throw new Error('Unable to locate stripes-webpack path.', tryPaths);
     }
-    logger.log(`using stripes-core: ${found}`);
+    logger.log(`using stripes-webpack: ${found}`);
     return found;
   }
 
   getCoreModulePath(moduleId) {
     const coreModulePath = (this.corePath === this.coreAlias)
       ? path.join(this.corePath, moduleId)
-      : resolveFrom(this.corePath, `@folio/stripes-core/${moduleId}`);
+      : resolveFrom(this.corePath, `@folio/stripes-webpack/${moduleId}`);
     return coreModulePath;
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-cli",
-  "version": "1.20.0",
+  "version": "2.0.0",
   "description": "Stripes Command Line Interface",
   "repository": "https://github.com/folio-org/stripes-cli",
   "publishConfig": {
@@ -22,8 +22,8 @@
     "docs": "node ./lib/doc/generator"
   },
   "dependencies": {
-    "@folio/stripes-core": "^2.17.1 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
     "@folio/stripes-testing": "^2.0.0",
+    "@folio/stripes-webpack": "^1.0.0",
     "@octokit/rest": "^17.1.4",
     "babel-plugin-istanbul": "^4.1.6",
     "configstore": "^3.1.1",
@@ -60,6 +60,8 @@
     "resolve-from": "^4.0.0",
     "resolve-pkg": "^1.0.0",
     "rimraf": "^2.6.2",
+    "rxjs": "^5.5.0",
+    "rxjs-compat": "^6.5.4",
     "semver": "^5.6.0",
     "simple-git": "^1.89.0",
     "supports-color": "^4.5.0",


### PR DESCRIPTION
Webpack config has been moved to `stripes-webpack` out of `stripes-core`. This PR is switching to stripes-webpack.