### PR TITLE
STCLI-176 pin stripes-webpack to ~1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-cli
 
+## 2.1.1 (IN PROGRESS)
+
+* Pin `@folio/stripes-webpack` to `~1.1.0`. Refs STCLI-176.
+
 ## [2.1.0](https://github.com/folio-org/stripes-cli/tree/v2.1.0) (2021-03-18)
 
 * Increment `@folio/stripes-testing` to `v3`, adding `interactors`, removing `nightmarejs`. Refs STCLI-171.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@folio/stripes-testing": "^3.0.0",
-    "@folio/stripes-webpack": "^1.0.0",
+    "@folio/stripes-webpack": "~1.1.0",
     "@octokit/rest": "^17.1.4",
     "babel-plugin-istanbul": "^4.1.6",
     "configstore": "^3.1.1",


### PR DESCRIPTION
For some users, `stripes-webpack` `^1.2.0` causes test failures that are
not present in `1.1.0`. It is not clear how these failures are related
as they do not occur for all users. It may be a `yarn` problem, or
something else environmental that we haven't sussed out yet. The errors
look like
```
...
ERROR in ./test/bigtest/tests/instance-edit-page-test.js
Module not found: Error: Can't resolve 'react/jsx-runtime' in '/Users/zburke/temp/ui-inventory/test/bigtest/tests'
 @ ./test/bigtest/tests/instance-edit-page-test.js 15:0-48 28:28-32
 @ ./test/bigtest/tests sync -test
 @ ./test/bigtest/index.js
ℹ ｢wdm｣: Failed to compile.
19 04 2021 11:38:30.042:WARN [karma]: No captured browser, open http://localhost:9876/
19 04 2021 11:38:30.047:INFO [karma-server]: Karma v4.4.1 server started at http://0.0.0.0:9876/
19 04 2021 11:38:30.047:INFO [launcher]: Launching browsers Chrome with concurrency unlimited
19 04 2021 11:38:30.389:INFO [launcher]: Starting browser Chrome
19 04 2021 11:38:33.744:INFO [Chrome 89.0.4389 (Mac OS X 10.15.7)]: Connected on socket hJU3kuwXwYihkABNAAAA with id 70570638
START:
Chrome 89.0.4389 (Mac OS X 10.15.7) ERROR
 Uncaught Error: Cannot find module 'react/jsx-runtime'
 at test/bigtest/index.js:62323:127
 Error: Cannot find module 'react/jsx-runtime'
   at webpackMissingModule (test/bigtest/index.js:62323:45)
   at Module.<anonymous> (test/bigtest/index.js:62323:137)
   at Module../node_modules/@folio/stripes-connect/ConnectContext.js (test/bigtest/index.js:62432:30)
   at __webpack_require__ (test/bigtest/index.js:64:30)
   at Module.<anonymous> (test/bigtest/index.js:64356:73)
   at Module../node_modules/@folio/stripes-connect/connect.js (test/bigtest/index.js:64776:30)
   at __webpack_require__ (test/bigtest/index.js:64:30)
   at Module.<anonymous> (test/bigtest/index.js:81958:80)
   at Module../node_modules/@folio/stripes-core/test/bigtest/helpers/setup-application.js (test/bigtest/index.js:82121:30)
   at __webpack_require__ (test/bigtest/index.js:64:30)
```
which we thought was related to having `react` less than `16.14.0` in
the build since the new JSX tranforms are only available in `^16.14.0 ||
17.0.0`, but some users see the failures even when v16.14 is present.

Refs [STCLI-176](https://issues.folio.org/browse/STCLI-176)