### PR TITLE
bump @folio/stripes-webpack to 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Bump `mocha` to `^8.3.0`.
 * Bump `babel-plugin-istanbul`, `karma`, `karma-mocha` and `webpack-bundle-analyzer` to avoid security warnings. Refs STCLI-179.
+* Bump `@folio/stripes-webpack` to `1.3.0` to reduce build warnings and allow transpiling of non-`@folio` namespaced modules.
 
 ## [2.2.0](https://github.com/folio-org/stripes-cli/tree/v2.2.0) (2021-04-13)
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@folio/stripes-testing": "^3.0.0",
-    "@folio/stripes-webpack": "^1.2.0",
+    "@folio/stripes-webpack": "^1.3.0",
     "@octokit/rest": "^17.1.4",
     "babel-plugin-istanbul": "^6.0.0",
     "configstore": "^3.1.1",


### PR DESCRIPTION
Bump `@folio/stripes-webpack` to reduce build warnings and allow
transpilation of modules outside the `@folio` namespace.