### PR TITLE
STCLI-178 Updated @octokit/rest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for stripes-cli
 
+## 2.4.0 In progress
+* Updated @octokit/rest to ^10.6.0 so that @octokit/core > 3 peerDependency could be resolved. Refs STCLI-178.
+
 ## [2.3.0](https://github.com/folio-org/stripes-cli/tree/v2.3.0) (2021-06-08)
 
 * Bump `mocha` to `^8.3.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for stripes-cli
 
-## 2.4.0 In progress
+## [2.3.1](https://github.com/folio-org/stripes-cli/tree/v2.3.1) (2021-06-15)
 * Updated @octokit/rest to ^10.6.0 so that @octokit/core > 3 peerDependency could be resolved. Refs STCLI-178.
 
 ## [2.3.0](https://github.com/folio-org/stripes-cli/tree/v2.3.0) (2021-06-08)

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@folio/stripes-testing": "^3.0.0",
     "@folio/stripes-webpack": "^1.3.0",
-    "@octokit/rest": "^17.1.4",
+    "@octokit/rest": "^18.6.0",
     "babel-plugin-istanbul": "^6.0.0",
     "configstore": "^3.1.1",
     "debug": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-cli",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Stripes Command Line Interface",
   "repository": "https://github.com/folio-org/stripes-cli",
   "publishConfig": {


### PR DESCRIPTION
so that @octokit/core > 3 peerDependency could be resolved. Refs [STCLI-178](https://issues.folio.org/browse/STCLI-178)

Based on breaking changes listed here: https://github.com/octokit/rest.js/releases/tag/v18.0.0, confirmed we are in the clear since our usage is low: https://github.com/folio-org/stripes-cli/blob/54d179bd43af73a4b4eef8ed8e5611cbc4af8e6d/lib/environment/inventory.js#L37

Confirmed correct behavior with `stripes workspace` command.