### PR TITLE
STCLI-182 re-export babel options from stripes-webpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-cli
 
+## 2.4.0 (IN PROGRESS)
+
+* Export babel config. Refs STCLI-182, STRIPES-742.
+
 ## [2.3.1](https://github.com/folio-org/stripes-cli/tree/v2.3.1) (2021-06-15)
 * Updated @octokit/rest to ^10.6.0 so that @octokit/core > 3 peerDependency could be resolved. Refs STCLI-178.
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,6 @@
+const { babelConfig } = require('@folio/stripes-webpack'); 
+
+module.exports = {
+  babelConfig,
+};
+

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const { babelConfig } = require('@folio/stripes-webpack'); 
+const { babelConfig } = require('@folio/stripes-webpack');
 
 module.exports = {
   babelConfig,

--- a/lib/environment/inventory.js
+++ b/lib/environment/inventory.js
@@ -70,10 +70,10 @@ const allModules = () => {
   return readModules();
 };
 
-const stripesModules = function () {
+function stripesModules() {
   const mods = readModules();
   return mods.libs;
-};
+}
 
 // Add the @folio scope, omitting "ui-" prefix if necessary
 function toFolioName(theModule) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-cli",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Stripes Command Line Interface",
   "repository": "https://github.com/folio-org/stripes-cli",
   "publishConfig": {
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@folio/stripes-testing": "^3.0.0",
-    "@folio/stripes-webpack": "^1.3.0",
+    "@folio/stripes-webpack": "^1.4.0",
     "@octokit/rest": "^18.6.0",
     "babel-plugin-istanbul": "^6.0.0",
     "configstore": "^3.1.1",
@@ -71,9 +71,9 @@
     "yargs": "^13.1.0"
   },
   "devDependencies": {
-    "@folio/eslint-config-stripes": "^5.2.0",
+    "@folio/eslint-config-stripes": "^6.0.0",
     "chai": "^4.1.2",
-    "eslint": "^6.2.1",
+    "eslint": "^7.32.0",
     "sinon": "^4.1.4",
     "sinon-chai": "^2.14.0"
   }


### PR DESCRIPTION
Re-export the babel config options import from `@folio/stripes-webpack`
so that modules needing access to it for Jest/RTL testing do not need to
maintain their own local copies.

Refs [STCLI-182](https://issues.folio.org/browse/STCLI-182)