### PR TITLE
STCLI-182 export babelOptions, not babelConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.4.0 (IN PROGRESS)
 
-* Export babel config. Refs STCLI-182, STRIPES-742.
+* Re-export babel config options. Refs STCLI-182, STRIPES-742.
 
 ## [2.3.1](https://github.com/folio-org/stripes-cli/tree/v2.3.1) (2021-06-15)
 * Updated @octokit/rest to ^10.6.0 so that @octokit/core > 3 peerDependency could be resolved. Refs STCLI-178.

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-const { babelConfig } = require('@folio/stripes-webpack');
+const { babelOptions } = require('@folio/stripes-webpack');
 
 module.exports = {
-  babelConfig,
+  babelOptions,
 };
 


### PR DESCRIPTION
`babelConfig` is not exported from `stripes-webpack`, [`babelOptions` is](https://github.com/folio-org/stripes-webpack/blob/56188f6ddffafab7d80ce53e9f36987297dd3e24/index.js#L3).
Re-export that one.

Corrects the typo in #265 that made it into a do-nothing PR.

Refs [STCLI-182](https://issues.folio.org/browse/STCLI-182)