### PR TITLE
STCLI-183 Storybook 6 - stripes-components special case for style aliases.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.4.0 (IN PROGRESS)
 
 * Re-export babel config options. Refs STCLI-182, STRIPES-742.
+* Conditionally inject webpack aliases for shared stripes-components styles based on context. Refs STCLI-183.
 
 ## [2.3.1](https://github.com/folio-org/stripes-cli/tree/v2.3.1) (2021-06-15)
 * Updated @octokit/rest to ^10.6.0 so that @octokit/core > 3 peerDependency could be resolved. Refs STCLI-178.

--- a/lib/commands/test/karma.js
+++ b/lib/commands/test/karma.js
@@ -34,7 +34,7 @@ function karmaCommand(argv) {
     bundle: argv.bundle,
     webpackOverrides,
   };
-  const webpackConfig = stripes.getStripesWebpackConfig(platform.getStripesConfig(), webpackConfigOptions);
+  const webpackConfig = stripes.getStripesWebpackConfig(platform.getStripesConfig(), webpackConfigOptions, context);
 
   const karmaService = new KarmaService(context.cwd);
   karmaService.runKarmaTests(webpackConfig, argv.karma);

--- a/lib/test/webpack-config.js
+++ b/lib/test/webpack-config.js
@@ -9,8 +9,8 @@ module.exports = function getStripesWebpackConfig(stripeCore, stripesConfig, opt
   // TODO: Switch between dev and prod files bases on env
   let config = stripeCore.getCoreModule('webpack.config.cli.dev');
 
-  // add webpack aliases for shared styles if the context is outside of @folio/stripes components.
-  // This d
+  // get the webpack aliases for shared styles from stripes-components.
+  // They will be added if the context is outside of @folio/stripes components.
   const addStyleAliases = stripeCore.getCoreModule('webpack.config.cli.dev.shared.styles');
   config = addStyleAliases(config, context);
 

--- a/lib/test/webpack-config.js
+++ b/lib/test/webpack-config.js
@@ -2,12 +2,17 @@ const path = require('path');
 
 // TODO: Move this to stripes-core and expose as part of the Stripes Node API
 // Generates a webpack config for Stripes independent of build or serve
-module.exports = function getStripesWebpackConfig(stripeCore, stripesConfig, options) {
+module.exports = function getStripesWebpackConfig(stripeCore, stripesConfig, options, context) {
   const StripesWebpackPlugin = stripeCore.getCoreModule('webpack/stripes-webpack-plugin');
   const applyWebpackOverrides = stripeCore.getCoreModule('webpack/apply-webpack-overrides');
 
   // TODO: Switch between dev and prod files bases on env
   let config = stripeCore.getCoreModule('webpack.config.cli.dev');
+
+  // add webpack aliases for shared styles if the context is outside of @folio/stripes components.
+  // This d
+  const addStyleAliases = stripeCore.getCoreModule('webpack.config.cli.dev.shared.styles');
+  config = addStyleAliases(config, context);
 
   // Omit all other entry points and don't bother adding stripes plugins when tests don't require a platform
   if (options.omitPlatform) {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@folio/stripes-testing": "^3.0.0",
-    "@folio/stripes-webpack": "folio-org/stripes-webpack#storybook-6",
+    "@folio/stripes-webpack": "^1.4.0",
     "@octokit/rest": "^18.6.0",
     "babel-plugin-istanbul": "^6.0.0",
     "configstore": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@folio/stripes-testing": "^3.0.0",
-    "@folio/stripes-webpack": "^1.4.0",
+    "@folio/stripes-webpack": "folio-org/stripes-webpack#storybook-6",
     "@octokit/rest": "^18.6.0",
     "babel-plugin-istanbul": "^6.0.0",
     "configstore": "^3.1.1",


### PR DESCRIPTION
### Problem
 Since stripes-components IS the dependency that the new webpack aliases reference, they won't resolve in CI for stripes-components - so they were failing when the webpack configuration was processed - which meant a dead test suite...

### Approach
Needed to conditionally omit the webpack aliases for shared styles when running from an isolated clone of stripes-components - so I passed stripes-cli context into a function that would inject the new aliases into the webpack dev configuration in non stripes-components cases.

The history:
Upgrading the stripes postcss stack...was many multiple breaking versions behind...
Upgraded CSS-loader left with unresolved imports.
CSS-loader's proposed fix: webpack aliases
Conditional logic needed for injecting the aliases (this PR)

PR in [stripes-components](https://github.com/folio-org/stripes-components/pull/1598) depends on this...