### PR TITLE
STCLI-188 avoid sabotaged colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [2.5.0] (IN PROGRESS)
 
 * Update webpack to v5. Refs STCLI-187.
+* Avoid sabotaged `colors`. Refs STCLI-188.
 
 ## [2.4.0](https://github.com/folio-org/stripes-cli/tree/v2.4.0) (2021-09-24)
 

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   "devDependencies": {
     "@folio/eslint-config-stripes": "^6.0.0",
     "chai": "^4.1.2",
+    "colors": "1.4.0",
     "eslint": "^7.32.0",
     "sinon": "^4.1.4",
     "sinon-chai": "^2.14.0"


### PR DESCRIPTION
Avoid the sabotaged `colors` module by adding a dev-dep on the
last-known-good build, `1.4.0`. Using a dev-dep, even though `colors` is
technically only a transitive dep, allows both `yarn` and `npm` to
handle this change. In yarn-land, arguably a `resolutions` entry would
be more correct, but that would only work in yarn-land.

Refs [STCLI-188](https://issues.folio.org/browse/STCLI-188)