### PR TITLE
avoid buggy transitive deps from @folio/stripes-webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@folio/stripes-testing": "^3.0.0",
-    "@folio/stripes-webpack": "^3.0.0",
+    "@folio/stripes-webpack": "^3.0.3",
     "@octokit/rest": "^18.6.0",
     "babel-plugin-istanbul": "^6.0.0",
     "configstore": "^3.1.1",


### PR DESCRIPTION
`@folio/stripes-webpack` published `v3.0.3` to avoid bugs in a
dependency (https://github.com/cerner/terra-toolkit/issues/730) so we
need to set `v3.0.3` as the minimum version here.