### PR TITLE
STCLI-193 avoid sabotaged isBinaryFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-cli
 
+## 2.6.0 (IN PROGRESS)
+
+* Avoid sabotaged `isBinaryFile`. Fixes STCLI-193.
+
 ## [2.5.0](https://github.com/folio-org/stripes-cli/tree/v2.5.0) (2022-02-08)
 
 * Update webpack to v5. Refs STCLI-187.

--- a/package.json
+++ b/package.json
@@ -75,5 +75,8 @@
     "eslint": "^7.32.0",
     "sinon": "^4.1.4",
     "sinon-chai": "^2.14.0"
+  },
+  "resolutions": {
+    "isbinaryfile": "4.0.8"
   }
 }


### PR DESCRIPTION
A breaking change to node compatibilty for `isBinaryFile`, a transitive
dependency via `karma`, was published in a patch release. It isn't clear
if the author doesn't understand semantic versioning or just doesn't
care about it, but multiple pleas to move the changes to a new major
version and publish a patch to restore compatibility in the 4.0.x line
were rebuffed (https://github.com/gjtorikian/isBinaryFile/issues/51).

Refs [STCLI-193](https://issues.folio.org/browse/STCLI-193)