### PR TITLE
STCLI-195 avoid webpack > 5.69.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-cli
 
+## 2.6.0
+
+* Avoid `webpack` > `5.69.1` due to `moment` incompatibilities. Refs STCLI-195.
+
 ## [2.5.1](https://github.com/folio-org/stripes-cli/tree/v2.5.1) (2022-03-25)
 
 * Avoid sabotaged `isBinaryFile`. Fixes STCLI-193.

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "simple-git": "^1.89.0",
     "supports-color": "^4.5.0",
     "update-notifier": "^2.3.0",
-    "webpack": "^5.58.1",
+    "webpack": "5.69.1",
     "webpack-bundle-analyzer": "^4.4.2",
     "yargs": "^13.1.0"
   },


### PR DESCRIPTION
`webpack` `5.69.0` and `5.70.1` introduced changes to "handle multiple
alternative directories (e. g. due to resolve.alias or resolve.modules)
when creating an context module" that appear to be incompatible with the
way moment handles dynamic loading of locales. That change was reverted
in `5.69.1` and then re-applied in `5.70.0`, hence the choice of
`5.69.1` here.

Honestly, the details are fuzzy but the incompatibility (in the form of
~7k lines of warnings) is indisputable. I believe the issue is captured
by https://github.com/moment/moment/issues/5492. It feels like `moment`
was built in a pre-ESM world and just can't cope with how things have
evolved since.

Refs [STCLI-195](https://issues.folio.org/browse/STCLI-195)