### PR TITLE
STCLI-195 pin webpack to ~5.68.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.6.0 IN PROGRESS
 
-* Avoid `webpack` > `5.69.1` due to `moment` incompatibilities. Refs STCLI-195.
+* Pin `webpack` to `~5.68.0` due to `moment` and `karma-webpack` trouble. Refs STCLI-195.
 
 ## [2.5.1](https://github.com/folio-org/stripes-cli/tree/v2.5.1) (2022-03-25)
 

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "simple-git": "^1.89.0",
     "supports-color": "^4.5.0",
     "update-notifier": "^2.3.0",
-    "webpack": "5.69.1",
+    "webpack": "~5.68.0",
     "webpack-bundle-analyzer": "^4.4.2",
     "yargs": "^13.1.0"
   },


### PR DESCRIPTION
Oy, the hits just keep coming. It seems that `5.69.0` and `5.70.0` don't
play nice with `moment` and barf thousands of lines of warnings into the
log when running tests, but `5.69.1` isn't compatible with
`karma-webpack` which prevents tests from running _at all_. Yuck.

Sample build output: 
```
$ stripes test karma --karma.singleRun --karma.browsers ChromeDocker --karma.reporters mocha junit --coverage
Starting Karma tests...
01 04 [20](https://github.com/folio-org/stripes-core/runs/5789164817?check_suite_focus=true#step:13:20)[22](https://github.com/folio-org/stripes-core/runs/5789164817?check_suite_focus=true#step:13:22) 14:07:[29](https://github.com/folio-org/stripes-core/runs/5789164817?check_suite_focus=true#step:13:29).960:ERROR [plugin]: Cannot find plugin "karma-webpack".
  Did you forget to install it?
  npm install karma-webpack --save-dev
01 04 2022 14:07:30.187:ERROR [plugin]: Cannot load "webpack", it is not registered!
  Perhaps you are missing some plugin?
01 04 2022 14:07:30.188:ERROR [karma-server]: Server start failed on port 9876: Error: No provider for "framework:webpack"! (Resolving: framework:webpack)
Karma exited with 1
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Error: Process completed with exit code 1.
```

Refs [STCLI-195](https://issues.folio.org/browse/STCLI-195)