### PR TITLE
STCLI-209 provide "--cache false" to disable webpack cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Upgrade `simple-git` to `^3.5.0` to avoid command injection vulnerability. Refs STCLI-200, STCLI-192.
 * Upgrade `stripes-webpack` to `^4.0.0`. Refs STCLI-203.
 * Update NodeJS to Active LTS. Refs STCLI-208.
+* Provide `--cache false` to disable webpack caching. Refs STCLI-209.
 
 ## [2.5.1](https://github.com/folio-org/stripes-cli/tree/v2.5.1) (2022-03-25)
 

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -1117,7 +1117,7 @@ Positional | Description | Type | Notes
 
 Option | Description | Type | Notes
 ---|---|---|---
-`--cache` | Use HardSourceWebpackPlugin cache | boolean |
+`--cache` | Use webpack cache | boolean | default: true
 `--coverage` | Enable coverage generation | boolean |
 `--devtool` | Specify the Webpack devtool for generating source maps | string |
 `--existing-build` | Serve an existing build from the supplied directory | string |
@@ -1191,7 +1191,7 @@ Positional | Description | Type | Notes
 
 Option | Description | Type | Notes
 ---|---|---|---
-`--cache` | Use HardSourceWebpackPlugin cache | boolean |
+`--cache` | Use webpack cache | boolean | default: true
 `--hasAllPerms` | Set "hasAllPerms" in Stripes config | boolean |
 `--host` | Development server host | string | default: "localhost"
 `--languages` | Languages to include in tenant build | array |

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -1,5 +1,3 @@
-const { ignoreCache } = require('../webpack-common');
-
 const importLazy = require('import-lazy')(require);
 
 const { contextMiddleware } = importLazy('../cli/context-middleware');

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -1,3 +1,5 @@
+const { ignoreCache } = require('../webpack-common');
+
 const importLazy = require('import-lazy')(require);
 
 const { contextMiddleware } = importLazy('../cli/context-middleware');
@@ -5,7 +7,7 @@ const { stripesConfigMiddleware } = importLazy('../cli/stripes-config-middleware
 const StripesCore = importLazy('../cli/stripes-core');
 const StripesPlatform = importLazy('../platform/stripes-platform');
 const { okapiOptions, stripesConfigFile, stripesConfigStdin, stripesConfigOptions, buildOptions } = importLazy('./common-options');
-const { processError, processStats, emitLintWarnings, limitChunks } = importLazy('../webpack-common');
+const { processError, processStats, emitLintWarnings, limitChunks, ignoreCache } = importLazy('../webpack-common');
 
 let _stripesPlatform;
 let _stripesCore;
@@ -53,6 +55,9 @@ function buildCommand(argv) {
   }
   if (argv.maxChunks) {
     webpackOverrides.push(limitChunks(argv.maxChunks));
+  }
+  if (argv.cache === false) {
+    webpackOverrides.push(ignoreCache);
   }
   if (context.plugin && context.plugin.beforeBuild) {
     webpackOverrides.push(context.plugin.beforeBuild(argv));

--- a/lib/commands/common-options.js
+++ b/lib/commands/common-options.js
@@ -11,11 +11,6 @@ module.exports.serverOptions = {
     default: 'localhost',
     group: 'Server Options:',
   },
-  cache: {
-    type: 'boolean',
-    describe: 'Use HardSourceWebpackPlugin cache',
-    group: 'Server Options:',
-  },
 };
 
 module.exports.authOptions = {
@@ -131,6 +126,11 @@ module.exports.buildOptions = {
   maxChunks: {
     type: 'number',
     describe: 'Limit the number of Webpack chunks in build output',
+  },
+  cache: {
+    type: 'boolean',
+    describe: 'Use webpack cache',
+    default: true,
   },
 };
 

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -5,7 +5,7 @@ const { stripesConfigMiddleware } = importLazy('../cli/stripes-config-middleware
 const StripesCore = importLazy('../cli/stripes-core');
 const StripesPlatform = importLazy('../platform/stripes-platform');
 const { serverOptions, okapiOptions, stripesConfigFile, stripesConfigStdin, stripesConfigOptions, buildOptions } = importLazy('./common-options');
-const { processError, emitLintWarnings, limitChunks, enableMirage, enableCoverage } = importLazy('../webpack-common');
+const { processError, emitLintWarnings, limitChunks, enableMirage, enableCoverage, ignoreCache } = importLazy('../webpack-common');
 const server = importLazy('../server');
 
 // stripes-core does not currently support publicPath with the dev server
@@ -50,6 +50,11 @@ function serveCommand(argv) {
   if (argv.maxChunks) {
     webpackOverrides.push(limitChunks(argv.maxChunks));
   }
+
+  if (argv.cache === false) {
+    webpackOverrides.push(ignoreCache);
+  }
+
 
   if (argv.mirage) {
     console.info('Using Mirage server');

--- a/lib/webpack-common.js
+++ b/lib/webpack-common.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const path = require('path');
-const { configurationErrorTask } = require('simple-git/dist/src/lib/tasks/task');
 const webpack = require('webpack');
 const logger = require('./cli/logger')('webpack');
 
@@ -112,9 +111,7 @@ function enableMirage(scenario) {
 }
 
 function ignoreCache(config) {
-  return (config) => {
-    return { ...config, cache: false };
-  };
+  return { ...config, cache: false };
 }
 
 module.exports = {

--- a/lib/webpack-common.js
+++ b/lib/webpack-common.js
@@ -112,7 +112,9 @@ function enableMirage(scenario) {
 }
 
 function ignoreCache(config) {
-  return { ...config, cache: false };
+  return (config) => {
+    return { ...config, cache: false };
+  };
 }
 
 module.exports = {

--- a/lib/webpack-common.js
+++ b/lib/webpack-common.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { configurationErrorTask } = require('simple-git/dist/src/lib/tasks/task');
 const webpack = require('webpack');
 const logger = require('./cli/logger')('webpack');
 
@@ -110,6 +111,10 @@ function enableMirage(scenario) {
   };
 }
 
+function ignoreCache(config) {
+  return { ...config, cache: false };
+}
+
 module.exports = {
   processError,
   processStats,
@@ -119,4 +124,5 @@ module.exports = {
   limitChunks,
   enableCoverage,
   enableMirage,
+  ignoreCache,
 };

--- a/test/commands/build.spec.js
+++ b/test/commands/build.spec.js
@@ -1,7 +1,7 @@
 const expect = require('chai').expect;
 const buildAppCommand = require('../../lib/commands/build');
 
-const { processError, processStats, emitLintWarnings, limitChunks, ignoreCache } = require('../../lib/webpack-common');
+const { ignoreCache } = require('../../lib/webpack-common');
 
 const packageJsonStub = {};
 const tenantConfig = {};

--- a/test/commands/build.spec.js
+++ b/test/commands/build.spec.js
@@ -1,6 +1,7 @@
 const expect = require('chai').expect;
-
 const buildAppCommand = require('../../lib/commands/build');
+
+const { processError, processStats, emitLintWarnings, limitChunks, ignoreCache } = require('../../lib/webpack-common');
 
 const packageJsonStub = {};
 const tenantConfig = {};
@@ -61,5 +62,14 @@ describe('The app create command', function () {
     expect(stripesCoreStub.api.build).to.have.been.calledWith(tenantConfig, expectedArgs);
     expect(console.log).to.have.been.calledWithMatch('Building...');
     done();
+  });
+
+  it('turns off webpack caching when --output flag is used.', function () {
+    const expectedArgs = Object.assign({}, this.argv, { cache: false, outputPath: './output', webpackOverrides: [ignoreCache] });
+    this.sut.stripesOverrides(platformStub, stripesCoreStub);
+    this.sut.handler(Object.assign({}, this.argv, { cache: false }));
+
+    expect(buildAppCommand.handler).to.have.been.calledOnce;
+    expect(stripesCoreStub.api.build).to.have.been.calledWith(tenantConfig, expectedArgs);
   });
 });

--- a/test/webpack-common.spec.js
+++ b/test/webpack-common.spec.js
@@ -51,4 +51,10 @@ describe('The webpack-common module', function () {
       expect(result.resolveLoader.modules).to.not.include('path/to/yarn/global/npm_modules');
     });
   });
+
+  describe('ignoreCache', () => {
+    it('"--cache false" turns off caching', () => {
+      expect(webpackCommon.ignoreCache({})).to.eql({ cache: false });
+    });
+  });
 });


### PR DESCRIPTION
Webpack caches build output by default. Most of the time, that's what we
want, so that's good. But sometimes it isn't what we want, and we need
an easy way to turn it off, so now there's `--cache false` for that.

Refs [STCLI-209](https://issues.folio.org/browse/STCLI-209)