### PR TITLE
STCLI-198 correctly implement caching, watching (default to true when CLI flags are absent)

### DIFF
--- a/lib/commands/test/karma.js
+++ b/lib/commands/test/karma.js
@@ -37,7 +37,7 @@ function karmaCommand(argv) {
   const webpackConfig = stripes.getStripesWebpackConfig(platform.getStripesConfig(), webpackConfigOptions, context);
 
   const karmaService = new KarmaService(context.cwd);
-  karmaService.runKarmaTests(webpackConfig, argv.karma);
+  karmaService.runKarmaTests(webpackConfig, Object.assign({}, argv.karma, { watch: argv.watch, cache: argv.cache }));
 }
 
 module.exports = {

--- a/lib/test/karma-service.js
+++ b/lib/test/karma-service.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const _pickBy = require('lodash/pickBy');
 const { Server, config } = require('karma');
 const logger = require('../cli/logger')('karma');
 
@@ -44,8 +45,11 @@ module.exports = class KarmaService {
     // set webpack's watch/cache features via karma config.
     // these features are unnecessary in the CI environment, so we turn them off by default.
     // They can be enabled individually via command-line options '--watch' and '--cache'.
-    const watch = !!karmaOptions?.watch;
-    const cache = !!karmaOptions?.cache;
+    let webpackTestConfig = {};
+    webpackTestConfig.watch = !!karmaOptions?.watch;
+    webpackTestConfig.cache = !!karmaOptions?.cache;
+    // only apply 'false' options as overrides to what karma-webpack wants to set.
+    webpackTestConfig = _pickBy((opt) => opt === false);
 
     let karmaConfig = {
       frameworks: ['mocha', 'webpack'],
@@ -96,8 +100,7 @@ module.exports = class KarmaService {
 
       webpack: {
         ...webpackConfigRest,
-        watch,
-        cache,
+        ...webpackTestConfig,
         output,
       },
       webpackMiddleware: {

--- a/lib/test/karma-service.js
+++ b/lib/test/karma-service.js
@@ -49,7 +49,7 @@ module.exports = class KarmaService {
     webpackTestConfig.watch = !!karmaOptions?.watch;
     webpackTestConfig.cache = !!karmaOptions?.cache;
     // only apply 'false' options as overrides to what karma-webpack wants to set.
-    webpackTestConfig = _pickBy((opt) => opt === false);
+    webpackTestConfig = _pickBy(webpackTestConfig, (opt) => !opt);
 
     let karmaConfig = {
       frameworks: ['mocha', 'webpack'],


### PR DESCRIPTION
The --watch and --cache options implemented in #290 added keys with `undefined` to the configuration object provided to webpack. These options would evaluate to `false`, so they would not effectively turn on the corresponding feature.
