### PR TITLE
STCLI-211: consume webpack.config.cli.dev as a function

### DIFF
--- a/lib/test/webpack-config.js
+++ b/lib/test/webpack-config.js
@@ -7,7 +7,9 @@ module.exports = function getStripesWebpackConfig(stripeCore, stripesConfig, opt
   const applyWebpackOverrides = stripeCore.getCoreModule('webpack/apply-webpack-overrides');
 
   // TODO: Switch between dev and prod files bases on env
-  let config = stripeCore.getCoreModule('webpack.config.cli.dev');
+  const buildConfig = stripeCore.getCoreModule('webpack.config.cli.dev');
+
+  let config = buildConfig(stripesConfig);
 
   // get the webpack aliases for shared styles from stripes-components.
   // They will be added if the context is outside of @folio/stripes components.


### PR DESCRIPTION
The recent changes in: https://github.com/folio-org/stripes-webpack/pull/63 changed the signature of the `webpack.config.cli.dev`. The configuration used to export a config (an object) but now it's a function so we need to adjust it here in stripes-cli.

https://issues.folio.org/browse/STCLI-211