### PR TITLE
Fix bug outputPath positional is ignored on build command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Correctly implement caching, watching (default to true when CLI flags are absent). Refs STCLI-198.
 * Consume `webpack.config.cli.dev` as a function, an accidental breaking change in STRWEB-49. Refs STCLI-211.
+* Fix outputPath positional is ignored on `build` command. Refs STCLI-165.
 
 ## [2.6.0](https://github.com/folio-org/stripes-cli/tree/v2.6.0) (2022-06-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Change history for stripes-cli
 
+## 2.6.2 IN PROGRESS
+
+* Fix outputPath positional is ignored on `build` command. Refs STCLI-165.
+
 ## [2.6.1](https://github.com/folio-org/stripes-cli/tree/v2.6.1) (2022-10-11)
 
 * Correctly implement caching, watching (default to true when CLI flags are absent). Refs STCLI-198.
 * Consume `webpack.config.cli.dev` as a function, an accidental breaking change in STRWEB-49. Refs STCLI-211.
-* Fix outputPath positional is ignored on `build` command. Refs STCLI-165.
 
 ## [2.6.0](https://github.com/folio-org/stripes-cli/tree/v2.6.0) (2022-06-14)
 

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -45,7 +45,7 @@ function buildCommand(argv) {
 
   if (argv.output) {
     argv.outputPath = argv.output;
-  } else {
+  } else if (!argv.outputPath) {
     argv.outputPath = './output';
   }
   if (argv.lint) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-cli",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Stripes Command Line Interface",
   "repository": "https://github.com/folio-org/stripes-cli",
   "publishConfig": {


### PR DESCRIPTION
- Fixes [STCLI-165](https://issues.folio.org/browse/STCLI-165)
- Bug was first introduced by [STCLI-95](https://issues.folio.org/browse/STCLI-95)
- Verified against `platform-core` with command `yarn stripes build stripes.config.js ./rb-test`