### PR TITLE
STCLI-220: Adjust webpack config for karma to avoid warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix outputPath positional is ignored on `build` command. Refs STCLI-165.
 * Add `stripes-ui` to the list of stripes modules. Refs STCLI-217.
+* Turn off `exprContextCritical` when running karma tests. Refs STCLI-220.
 
 ## [2.6.1](https://github.com/folio-org/stripes-cli/tree/v2.6.1) (2022-10-11)
 

--- a/lib/commands/test/karma.js
+++ b/lib/commands/test/karma.js
@@ -36,6 +36,18 @@ function karmaCommand(argv) {
   };
   const webpackConfig = stripes.getStripesWebpackConfig(platform.getStripesConfig(), webpackConfigOptions, context);
 
+  // This fixes the warnings similar to:
+  // WARNING in ./node_modules/mocha/mocha-es2018.js 18541:26-55
+  // Critical dependency: the request of a dependency is an expression
+  // https://github.com/mochajs/mocha/issues/2448#issuecomment-355222358
+  webpackConfig.module.exprContextCritical = false;
+
+  // This fixes warning:
+  // WARNING in DefinePlugin
+  // Conflicting values for 'process.env.NODE_ENV'
+  // https://webpack.js.org/configuration/mode/#usage
+  webpackConfig.mode = 'none';
+
   const karmaService = new KarmaService(context.cwd);
   karmaService.runKarmaTests(webpackConfig, Object.assign({}, argv.karma, { watch: argv.watch, cache: argv.cache }));
 }

--- a/lib/test/karma-service.js
+++ b/lib/test/karma-service.js
@@ -167,6 +167,12 @@ module.exports = class KarmaService {
     return karmaConfig;
   }
 
+  // This fixes the warnings similar to:
+  // WARNING in ./node_modules/mocha/mocha-es2018.js 18541:26-55
+  // Critical dependency: the request of a dependency is an expression
+  // https://github.com/mochajs/mocha/issues/2448#issuecomment-355222358
+  webpackConfig.module.exprContextCritical = false;
+
   // Runs the specified integration tests
   runKarmaTests(webpackConfig, karmaOptions) {
     const karmaConfig = this.generateKarmaConfig(webpackConfig, karmaOptions);

--- a/lib/test/karma-service.js
+++ b/lib/test/karma-service.js
@@ -167,18 +167,6 @@ module.exports = class KarmaService {
     return karmaConfig;
   }
 
-  // This fixes the warnings similar to:
-  // WARNING in ./node_modules/mocha/mocha-es2018.js 18541:26-55
-  // Critical dependency: the request of a dependency is an expression
-  // https://github.com/mochajs/mocha/issues/2448#issuecomment-355222358
-  webpackConfig.module.exprContextCritical = false;
-
-  // This fixes warning:
-  // WARNING in DefinePlugin
-  // Conflicting values for 'process.env.NODE_ENV'
-  // https://webpack.js.org/configuration/mode/#usage
-  webpackConfig.mode = 'none';
-
   // Runs the specified integration tests
   runKarmaTests(webpackConfig, karmaOptions) {
     const karmaConfig = this.generateKarmaConfig(webpackConfig, karmaOptions);

--- a/lib/test/karma-service.js
+++ b/lib/test/karma-service.js
@@ -173,6 +173,12 @@ module.exports = class KarmaService {
   // https://github.com/mochajs/mocha/issues/2448#issuecomment-355222358
   webpackConfig.module.exprContextCritical = false;
 
+  // This fixes warning:
+  // WARNING in DefinePlugin
+  // Conflicting values for 'process.env.NODE_ENV'
+  // https://webpack.js.org/configuration/mode/#usage
+  webpackConfig.mode = 'none';
+
   // Runs the specified integration tests
   runKarmaTests(webpackConfig, karmaOptions) {
     const karmaConfig = this.generateKarmaConfig(webpackConfig, karmaOptions);


### PR DESCRIPTION
https://issues.folio.org/browse/STCLI-220

This PR turns off `exprContextCritical` when karma/bigtest tests are running to avoid warnings similar to:

````js
WARNING in ./node_modules/mocha/mocha-es2018.js 18541:26-55
Critical dependency: the request of a dependency is an expression
 @ ./node_modules/@bigtest/mocha/dist/esm/index.js 1:0-75 3:22-30 5:20-26 7:24-34 9:19-24 11:23-32 13:16-18
 @ ./test/bigtest/tests/about-test.js 14:0-58 20:0-8 52:2-10 53:4-14 56:4-6
 @ ./test/bigtest/tests/ sync -test ./about-test.js ./about-test
 @ ./test/bigtest/index.js 10:18-60
````

It also sets webpack mode to `none` to avoid warnings similar to:

````js
WARNING in DefinePlugin
Conflicting values for 'process.env.NODE_ENV'
````