### PR TITLE
STCLI-227 lock stripes-webpack for stripes v7 compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@folio/stripes-testing": "^3.0.0",
-    "@folio/stripes-webpack": "^4.2.0",
+    "@folio/stripes-webpack": "~4.1.2",
     "@octokit/rest": "^18.6.0",
     "babel-plugin-istanbul": "^6.0.0",
     "configstore": "^3.1.1",


### PR DESCRIPTION
`stripes-webpack` >= `4.2.0` looks for its entrypoint in `stripes-ui` instead of `stripes-core`, where it look up until `stripes` `8.0.0`. In order to remain capable of building platforms based on `< 8.0.0`, `stripes-cli` must therefore lock onto `stripes-webpack` `~4.1`.

Refs [STCLI-227](https://github.com/folio-org/stripes-cli/pull/new/STCLI-227)