### PR TITLE
STCLI-224: Adjust path to shared styles

### DIFF
--- a/lib/test/webpack-config.js
+++ b/lib/test/webpack-config.js
@@ -13,7 +13,7 @@ module.exports = function getStripesWebpackConfig(stripeCore, stripesConfig, opt
 
   // get the webpack aliases for shared styles from stripes-components.
   // They will be added if the context is outside of @folio/stripes components.
-  const addStyleAliases = stripeCore.getCoreModule('webpack.config.cli.dev.shared.styles');
+  const addStyleAliases = stripeCore.getCoreModule('webpack.config.cli.shared.styles');
   config = addStyleAliases(config, context);
 
   // Omit all other entry points and don't bother adding stripes plugins when tests don't require a platform


### PR DESCRIPTION
This is a small fix related to transpilation work done in:

https://github.com/folio-org/stripes-webpack/pull/73

The path to shared styles has changed from `webpack.config.cli.dev.shared.styles` => `webpack.config.cli.shared.styles`

This PR is addressing it.