### PR TITLE
STCLI-231: Adjust finding babel-loader in webpack config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2.8.0 IN PROGRESS
 
+* Adjust finding `babel-loader` in webpack config in order to fix coverage. Fixes STCLI-231.
+
 ## [2.7.0](https://github.com/folio-org/stripes-cli/tree/v2.7.0) (2023-02-07)
 [Full Changelog](https://github.com/folio-org/stripes-cli/compare/v2.6.3...v2.7.0)
 

--- a/lib/test/webpack-config.js
+++ b/lib/test/webpack-config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const { set } = require('lodash');
 
 // TODO: Move this to stripes-core and expose as part of the Stripes Node API
 // Generates a webpack config for Stripes independent of build or serve
@@ -31,12 +32,14 @@ module.exports = function getStripesWebpackConfig(stripeCore, stripesConfig, opt
   // Inject babel-plugin-istanbul when coverage is enabled
   if (options.coverage) {
     const babelLoaderConfigIndex = config.module.rules.findIndex((rule) => {
-      return rule.loader === 'babel-loader';
+      return rule?.oneOf?.[1]?.use?.[0].loader === 'babel-loader';
     });
-    if (!config.module.rules[babelLoaderConfigIndex].options.plugins) {
-      config.module.rules[babelLoaderConfigIndex].options.plugins = [];
+
+    if (!config.module.rules[babelLoaderConfigIndex]?.oneOf?.[1].use[0].options?.plugins) {
+      set(config.module.rules[babelLoaderConfigIndex], 'oneOf[1].use[0].options.plugins', []);
     }
-    config.module.rules[babelLoaderConfigIndex].options.plugins.push(
+
+    config.module.rules[babelLoaderConfigIndex].oneOf[1].use[0].options.plugins.push(
       require.resolve('babel-plugin-istanbul')
     );
   }


### PR DESCRIPTION
https://issues.folio.org/browse/STCLI-231

After the work related to esbuild-loader has been merged the bigtest tests started failing when the coverage is turned on.

This is due to the fact that the babel-loader has been moved to a different location in webpack config.

https://github.com/folio-org/stripes-cli/blob/9af1d6181ea92ceacb390aa99c904a44511fbe04/lib/test/webpack-config.js#L34

This PR is trying to address it so the coverage works as expected.