### PR TITLE
STCLI-222 unpin webpack dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.8.0 IN PROGRESS
 
 * Adjust finding `babel-loader` in webpack config in order to fix coverage. Fixes STCLI-231.
+* Unpin `webpack` from `~5.68.0`. Refs STCLI-222.
 
 ## [2.7.0](https://github.com/folio-org/stripes-cli/tree/v2.7.0) (2023-02-07)
 [Full Changelog](https://github.com/folio-org/stripes-cli/compare/v2.6.3...v2.7.0)

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "simple-git": "^3.5.0",
     "supports-color": "^4.5.0",
     "update-notifier": "^5.1.0",
-    "webpack": "~5.68.0",
+    "webpack": "^5.78.0",
     "webpack-bundle-analyzer": "^4.4.2",
     "yargs": "^17.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "simple-git": "^3.5.0",
     "supports-color": "^4.5.0",
     "update-notifier": "^5.1.0",
-    "webpack": "^5.78.0",
+    "webpack": "^5.80.0",
     "webpack-bundle-analyzer": "^4.4.2",
     "yargs": "^17.3.1"
   },


### PR DESCRIPTION
We pinned webpack in [STCLI-195](https://issues.folio.org/browse/STCLI-195) but the build errors we encountered at that time have abated.

Refs [STCLI-222](https://issues.folio.org/browse/STCLI-222)