### PR TITLE
Bump update-notifier to 6.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Adjust finding `babel-loader` in webpack config in order to fix coverage. Fixes STCLI-231.
 * Upgrade `mocha` from 9 to 10 fixing ReDoS. Refs STCLI-226.
 * Unpin `webpack` from `~5.68.0`. Refs STCLI-222.
+* Bump `notifier` to `6.0.2`.
 
 ## [2.7.0](https://github.com/folio-org/stripes-cli/tree/v2.7.0) (2023-02-07)
 [Full Changelog](https://github.com/folio-org/stripes-cli/compare/v2.6.3...v2.7.0)

--- a/lib/stripes-cli.js
+++ b/lib/stripes-cli.js
@@ -2,7 +2,6 @@
 
 const yargs = require('yargs/yargs');
 const { hideBin } = require('yargs/helpers');
-const updateNotifier = require('update-notifier');
 const isInstalledGlobally = require('is-installed-globally');
 const packageJson = require('../package.json');
 const AliasError = require('./platform/alias-error');
@@ -12,15 +11,21 @@ const logger = require('./cli/logger')();
 process.title = 'stripes-cli';
 logger.log('stripes-cli', packageJson.version);
 
-// Update notifier runs async in a child process
-updateNotifier({
-  pkg: packageJson,
-  updateCheckInterval: 1000 * 60 * 60 * 24 * 7,
-}).notify({
-  isGlobal: isInstalledGlobally,
-  // TODO: Consider reverting to default message once update-notifier detects global yarn installs
-  message: 'Update available - Refer to README.md:\nhttps://github.com/folio-org/stripes-cli',
-});
+// update-notifier is pure ESM so needs to be loaded via dynamic import
+// until we refactor from CJS to ESM. Until then, say hello to our old
+// friend, the IIFE.
+(async () => {
+  // Update notifier runs async in a child process
+  const updateNotifier = await import('update-notifier');
+  updateNotifier.default({
+    pkg: packageJson,
+    updateCheckInterval: 1000 * 60 * 60 * 24 * 7,
+  }).notify({
+    isGlobal: isInstalledGlobally,
+    // TODO: Consider reverting to default message once update-notifier detects global yarn installs
+    message: 'Update available - Refer to README.md:\nhttps://github.com/folio-org/stripes-cli',
+  });
+})();
 
 try {
   yargs(hideBin(process.argv))

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "semver": "^5.6.0",
     "simple-git": "^3.5.0",
     "supports-color": "^4.5.0",
-    "update-notifier": "^5.1.0",
+    "update-notifier": "^6.0.2",
     "webpack": "^5.80.0",
     "webpack-bundle-analyzer": "^4.4.2",
     "yargs": "^17.3.1"


### PR DESCRIPTION
[`update-notifier`](https://github.com/yeoman/update-notifier) has shifted to pure-ESM but stripes-cli is still CJS. Eventually, we'll have to migrate as well, but for now we can just load `update-notifier` asynchronously.