### PR TITLE
Bump sinon to 15.0.4, sinon-chai to 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Adjust finding `babel-loader` in webpack config in order to fix coverage. Fixes STCLI-231.
 * Upgrade `mocha` from 9 to 10 fixing ReDoS. Refs STCLI-226.
 * Unpin `webpack` from `~5.68.0`. Refs STCLI-222.
+* Bump `sinon` to `15.0.4`, `sinon-chai` to `3.7.0`.
 
 ## [2.7.0](https://github.com/folio-org/stripes-cli/tree/v2.7.0) (2023-02-07)
 [Full Changelog](https://github.com/folio-org/stripes-cli/compare/v2.6.3...v2.7.0)

--- a/package.json
+++ b/package.json
@@ -72,9 +72,7 @@
     "@folio/eslint-config-stripes": "^6.0.0",
     "chai": "^4.1.2",
     "colors": "1.4.0",
-    "eslint": "^7.32.0",
-    "sinon": "^4.1.4",
-    "sinon-chai": "^2.14.0"
+    "eslint": "^7.32.0"
   },
   "resolutions": {
     "isbinaryfile": "4.0.8"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,9 @@
     "@folio/eslint-config-stripes": "^6.0.0",
     "chai": "^4.1.2",
     "colors": "1.4.0",
-    "eslint": "^7.32.0"
+    "eslint": "^7.32.0",
+    "sinon": "^15.0.4",
+    "sinon-chai": "^3.7.0"
   },
   "resolutions": {
     "isbinaryfile": "4.0.8"

--- a/test/test-setup.spec.js
+++ b/test/test-setup.spec.js
@@ -11,7 +11,7 @@ before(function () {
 
 beforeEach(function () {
   // The Sinon sandbox allows for easy cleanup of spies and stubs
-  this.sandbox = sinon.sandbox.create();
+  this.sandbox = sinon.createSandbox();
 });
 
 afterEach(function () {


### PR DESCRIPTION
Bump [`sinon`](https://github.com/sinonjs/sinon) from `4.1.4` to `15.0.4`. Breaking changes in sinon are not well-documented, even though `CHANGES.md` catalogs many new major versions. Given this is only a dev-dep and our tests still run with just a minor tweak, this implies that whatever surfaces _did_ change between versions 4 and 15 are not surfaces that we touched. Whew. 

Bump its companion [`sinon-chai`](https://github.com/domenic/sinon-chai) from `2.14.0` to `3.7.0`. The only breaking change here was in raising the minimum versions of node, sinon, and chai to versions we already require.