### PR TITLE
STCLI-231: Adjust finding  in webpack config in order to fix coverage

### DIFF
--- a/lib/test/webpack-config.js
+++ b/lib/test/webpack-config.js
@@ -1,6 +1,8 @@
 const path = require('path');
 const { set } = require('lodash');
 
+const { enableCoverage } = require('../webpack-common');
+
 // TODO: Move this to stripes-core and expose as part of the Stripes Node API
 // Generates a webpack config for Stripes independent of build or serve
 module.exports = function getStripesWebpackConfig(stripeCore, stripesConfig, options, context) {
@@ -31,17 +33,7 @@ module.exports = function getStripesWebpackConfig(stripeCore, stripesConfig, opt
 
   // Inject babel-plugin-istanbul when coverage is enabled
   if (options.coverage) {
-    const babelLoaderConfigIndex = config.module.rules.findIndex((rule) => {
-      return rule?.oneOf?.[1]?.use?.[0].loader === 'babel-loader';
-    });
-
-    if (!config.module.rules[babelLoaderConfigIndex]?.oneOf?.[1].use[0].options?.plugins) {
-      set(config.module.rules[babelLoaderConfigIndex], 'oneOf[1].use[0].options.plugins', []);
-    }
-
-    config.module.rules[babelLoaderConfigIndex].oneOf[1].use[0].options.plugins.push(
-      require.resolve('babel-plugin-istanbul')
-    );
+    enableCoverage(config);
   }
 
   // Remove HMR plugin during testing

--- a/lib/test/webpack-config.js
+++ b/lib/test/webpack-config.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const { set } = require('lodash');
 
 const { enableCoverage } = require('../webpack-common');
 

--- a/lib/webpack-common.js
+++ b/lib/webpack-common.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const webpack = require('webpack');
 const logger = require('./cli/logger')('webpack');
+const { set } = require('lodash');
 
 // Display error to the console and exit
 function processError(err) {

--- a/lib/webpack-common.js
+++ b/lib/webpack-common.js
@@ -1,8 +1,8 @@
 const fs = require('fs');
 const path = require('path');
+const { set } = require('lodash');
 const webpack = require('webpack');
 const logger = require('./cli/logger')('webpack');
-const { set } = require('lodash');
 
 // Display error to the console and exit
 function processError(err) {

--- a/lib/webpack-common.js
+++ b/lib/webpack-common.js
@@ -83,14 +83,17 @@ function limitChunks(maxChunks) {
 
 function enableCoverage(config) {
   const babelLoaderConfigIndex = config.module.rules.findIndex((rule) => {
-    return rule.loader === 'babel-loader';
+    return rule?.oneOf?.[1]?.use?.[0].loader === 'babel-loader';
   });
-  if (!config.module.rules[babelLoaderConfigIndex].options.plugins) {
-    config.module.rules[babelLoaderConfigIndex].options.plugins = [];
+
+  if (!config.module.rules[babelLoaderConfigIndex]?.oneOf?.[1].use[0].options?.plugins) {
+    set(config.module.rules[babelLoaderConfigIndex], 'oneOf[1].use[0].options.plugins', []);
   }
-  config.module.rules[babelLoaderConfigIndex].options.plugins.push(
+
+  config.module.rules[babelLoaderConfigIndex].oneOf[1].use[0].options.plugins.push(
     require.resolve('babel-plugin-istanbul')
   );
+
   return config;
 }
 


### PR DESCRIPTION
https://issues.folio.org/browse/STCLI-231

This was already fixed for bigtest tests in: https://github.com/folio-org/stripes-cli/pull/313

But I missed the fact that the same functionality is used for cypress tests.
