### PR TITLE
bump stripes-webpack to ~4.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-cli
 
+## 2.6.4 IN PROGRESS
+
+* Bump `stripes-webpack` to `~4.1.3` to include babel plugins. Refs STRWEB-86.
+
 ## [2.6.3](https://github.com/folio-org/stripes-cli/tree/v2.6.3) (2023-02-07)
 [Full Changelog](https://github.com/folio-org/stripes-cli/compare/v2.6.2...v2.6.3)
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@folio/stripes-testing": "^3.0.0",
-    "@folio/stripes-webpack": "~4.1.2",
+    "@folio/stripes-webpack": "~4.1.3",
     "@octokit/rest": "^18.6.0",
     "babel-plugin-istanbul": "^6.0.0",
     "configstore": "^3.1.1",


### PR DESCRIPTION
Bump `stripes-webpack` to `~4.1.3` to include babel plugins that are no longer part of `@babel/preset-env`.

Refs [STRWEB-86](https://issues.folio.org/browse/STRWEB-86)