### PR TITLE
Bump `stripes-webpack` to 4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-cli
 
+## 2.7.1 IN PROGRESS
+
+* Bump `stripes-webpack` to `~4.2.1` to include babel plugins. Refs STRWEB-86.
+
 ## [2.7.0](https://github.com/folio-org/stripes-cli/tree/v2.7.0) (2023-02-07)
 [Full Changelog](https://github.com/folio-org/stripes-cli/compare/v2.6.3...v2.7.0)
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@folio/stripes-testing": "^3.0.0",
-    "@folio/stripes-webpack": "^4.2.0",
+    "@folio/stripes-webpack": "^4.2.1",
     "@octokit/rest": "^18.6.0",
     "babel-plugin-istanbul": "^6.0.0",
     "configstore": "^3.1.1",


### PR DESCRIPTION
Bump `stripes-webpack` to `~4.2.1` to include babel plugins that are no longer part of `@babel/preset-env`.

Refs [STRWEB-86](https://issues.folio.org/browse/STRWEB-86)