### PR TITLE
STCLI-234 bump fast-xml-parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Bump `just-kebab-case` to `^4.2.0`.
 * Remove `isbinaryfile` resolution.
 * Bump devdeps `sinon` to `15.0.4`, `sinon-chai` to `3.7.0`.
+* Bump `fast-xml-parser` to `4.2.4`. Refs STRWEB-91.
 
 ## [2.7.0](https://github.com/folio-org/stripes-cli/tree/v2.7.0) (2023-02-07)
 [Full Changelog](https://github.com/folio-org/stripes-cli/compare/v2.6.3...v2.7.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Bump `just-kebab-case` to `^4.2.0`.
 * Remove `isbinaryfile` resolution.
 * Bump devdeps `sinon` to `15.0.4`, `sinon-chai` to `3.7.0`.
-* Bump `fast-xml-parser` to `4.2.4`. Refs STRWEB-91.
+* Bump `fast-xml-parser` to `4.2.4`. Refs STCLI-234.
 
 ## [2.7.0](https://github.com/folio-org/stripes-cli/tree/v2.7.0) (2023-02-07)
 [Full Changelog](https://github.com/folio-org/stripes-cli/compare/v2.6.3...v2.7.0)

--- a/lib/cli/context.js
+++ b/lib/cli/context.js
@@ -9,7 +9,7 @@ const logger = require('./logger')();
 const globalDirs = require('./global-dirs');
 const { stripesModules, toFolioName } = require('../environment/inventory');
 
-const xmlParser = importLazy('fast-xml-parser');
+const { XMLParser } = importLazy('fast-xml-parser');
 
 const cliRoot = path.join(__dirname, '..', '..');
 
@@ -39,7 +39,7 @@ function loadXml(filePath) {
   let xml;
   try {
     const data = fs.readFileSync(filePath, 'utf-8');
-    xml = xmlParser.parse(data);
+    xml = (new XMLParser()).parse(data);
   } catch (err) {
     console.log(err);
   }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "configstore": "^3.1.1",
     "debug": "^4.0.1",
     "express": "^4.17.1",
-    "fast-xml-parser": "^3.12.10",
+    "fast-xml-parser": "^4.2.4",
     "find-up": "^2.1.0",
     "fs-extra": "^11.1.1",
     "get-stdin": "^6.0.0",


### PR DESCRIPTION
Bump `fast-xml-parser` to avoid CVE-2023-34104, CVE-2023-26920

Refs [STCLI-234](https://issues.folio.org/browse/STCLI-234)