### PR TITLE
STCLI-235 update stripes-webpack to v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for stripes-cli
 
-## 2.8.0 IN PROGRESS
+## 3.0.0 IN PROGRESS
 
 * Adjust finding `babel-loader` in webpack config in order to fix coverage. Fixes STCLI-231.
 * Upgrade `mocha` from 9 to 10 fixing ReDoS. Refs STCLI-226.
@@ -13,6 +13,9 @@
 * Remove `isbinaryfile` resolution.
 * Bump devdeps `sinon` to `15.0.4`, `sinon-chai` to `3.7.0`.
 * Bump `fast-xml-parser` to `4.2.4`. Refs STCLI-234.
+* Bump devdeps `@folio/eslint-config-stripes` to `^7.0.0`.
+* *BREAKING* Bump `@folio/stripes-webpack` to `^5.0.0`. Refs STCLI-235.
+* *BREAKING* Bump devdep `@folio/eslint-config-stripes` to `^7.0.0` for stripes-webpack compat.
 
 ## [2.7.0](https://github.com/folio-org/stripes-cli/tree/v2.7.0) (2023-02-07)
 [Full Changelog](https://github.com/folio-org/stripes-cli/compare/v2.6.3...v2.7.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-cli",
-  "version": "2.8.0",
+  "version": "3.0.0",
   "description": "Stripes Command Line Interface",
   "repository": "https://github.com/folio-org/stripes-cli",
   "publishConfig": {
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@folio/stripes-testing": "^3.0.0",
-    "@folio/stripes-webpack": "^4.2.0",
+    "@folio/stripes-webpack": "^5.0.0",
     "@octokit/rest": "^19.0.7",
     "babel-plugin-istanbul": "^6.0.0",
     "configstore": "^3.1.1",
@@ -69,7 +69,7 @@
     "yargs": "^17.3.1"
   },
   "devDependencies": {
-    "@folio/eslint-config-stripes": "^6.0.0",
+    "@folio/eslint-config-stripes": "^7.0.0",
     "chai": "^4.1.2",
     "colors": "1.4.0",
     "eslint": "^7.32.0",


### PR DESCRIPTION
*BREAKING* Bump `@folio/stripes-webpack` to v5. stripes-cli re-exports portions of stripes-webpack and, from the point of view of applications with dev-deps on stripes-cli, represents the public API for stripes-webpack. Thus, even though stripes-webpack is a direct (and thus internal) dependency here, it functions more like a peer-dependency and since that version is changing, then this one must too.

Refs [STCLI-235](https://issues.folio.org/browse/STCLI-235)