### PR TITLE
STCLI-237 fix test coverage on BTOG tests.

### DIFF
--- a/lib/webpack-common.js
+++ b/lib/webpack-common.js
@@ -82,6 +82,40 @@ function limitChunks(maxChunks) {
   };
 }
 
+// shouldModuleBeIncluded -
+// this is a slimmed-down version of stripes-webpack's shouldModuleBeIncluded. We still need to
+// transpile things that need to be transpiled, which is our working project's files and any from an `@folio` scoped module.
+
+function shouldModuleBeIncluded(modulePath) {
+  const nodeModulesRegex = /node_modules/;
+
+  // https://stackoverflow.com/questions/3446170/escape-string-for-use-in-javascript-regex/6969486#6969486
+  const escapeRegExp = string => string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+  const folioModulePath = path.join('node_modules', '@folio');
+  const folioModulesRegex = new RegExp(`${escapeRegExp(folioModulePath)}(?!.*dist)`);
+
+  if (folioModulesRegex.test(modulePath)) {
+    return true;
+  }
+
+  // exclude empty modules
+  if (!modulePath) {
+    return false;
+  }
+
+  // skip everything from node_modules
+  if (nodeModulesRegex.test(modulePath)) {
+    return false;
+  }
+
+  return true;
+}
+
+// test coverage is activated by including the instrumentation plugin to the babel plugin stack.
+// the test stack currently includes es-build for dev and production, but unfortunately, the tool includes
+// no test coverage instrumentation :o( https://github.com/evanw/esbuild/issues/184
+
 function enableCoverage(config) {
   const babelLoaderConfigIndex = config.module.rules.findIndex((rule) => {
     return rule?.oneOf?.[1]?.use?.[0].loader === 'babel-loader';
@@ -91,10 +125,25 @@ function enableCoverage(config) {
     set(config.module.rules[babelLoaderConfigIndex], 'oneOf[1].use[0].options.plugins', []);
   }
 
+  // only use babel configuration for test coverage..
+  const babelConfigurationItem = config.module.rules[babelLoaderConfigIndex].oneOf[1];
+
+  // exclude files from coverage reports here.
   config.module.rules[babelLoaderConfigIndex].oneOf[1].use[0].options.plugins.push(
-    require.resolve('babel-plugin-istanbul')
+    [require.resolve('babel-plugin-istanbul'), {
+      exclude: [
+        '**/*.test.js',
+        '**/tests/*.js',
+        '**/stories/*.js',
+        '/node_modules/*'
+      ]
+    }]
   );
 
+  babelConfigurationItem.test = /\.js$/;
+  babelConfigurationItem.include = shouldModuleBeIncluded;
+
+  set(config.module, `rules[${babelLoaderConfigIndex}]`, babelConfigurationItem);
   return config;
 }
 


### PR DESCRIPTION
Stripes CLI splits compilation of files between babel and es-build. The problem is that the things we want coverage on the most are not instrumented through es-build, and thus far, I don't believe there is a way to do so, nor is there a [wish from the maintainers to prioritize this feature](https://github.com/evanw/esbuild/issues/184)

## Approach:
* exclude esbuild from tests for coverage sake
* properly configure `babel-plugin-istanbul` to exclude coverage reports on testing infrastructure.

TO DO:
Test outside of stripes-components...

Test coverage before: 😕 
![test file coverage](https://github.com/folio-org/stripes-cli/assets/20704067/ee681ab0-d792-4150-80a0-be74657d5c61)

Test coverage after: 🎉 
![image](https://github.com/folio-org/stripes-cli/assets/20704067/e8504de6-5142-44ac-99a9-9048c3734038)
