### PR TITLE
STCLI-246 Add a proxy server to overcome issues with cookies SameSite policy.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 3.2.0 IN PROGRESS
 
+* Add a proxy server to overcome issues with cookies SameSite policy. Refs STCLI-246.
+
 ## [3.1.0](https://github.com/folio-org/stripes-cli/tree/v3.1.0) (2024-03-12)
 [Full Changelog](https://github.com/folio-org/stripes-cli/compare/v3.0.0...v3.1.0)
 

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -1148,7 +1148,7 @@ Serve a build previously created with "stripes build":
 ```
 $ stripes serve --existing-build output
 ```
-Serve a platform with a local proxy server that points to remove okapi server:
+Serve a platform with a local proxy server that points to a remote okapi server:
 ```
 $ stripes serve --startProxy --proxyPort 3010 --okapi http://some-okapi-server.folio.org
 ```

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -1131,6 +1131,8 @@ Option | Description | Type | Notes
 `--port` | Development server port | number | default: 3000
 `--stripesConfig` | Stripes config JSON  | string | supports stdin
 `--tenant` | Specify a tenant ID | string |
+`--startProxy` | Start a local proxy server between the platform and okapi | boolean | default: false
+`--proxyPort` | Port number for the proxy server | number | default: 3010
 
 Examples:
 
@@ -1145,6 +1147,10 @@ $ stripes serve stripes.config.js
 Serve a build previously created with "stripes build":
 ```
 $ stripes serve --existing-build output
+```
+Serve a platform with a local proxy server that points to remove okapi server:
+```
+$ stripes serve --startProxy --proxyPort 3010 --okapi http://some-okapi-server.folio.org
 ```
 Serve an app (in app context) with a mock backend server":
 ```

--- a/lib/commands/common-options.js
+++ b/lib/commands/common-options.js
@@ -5,6 +5,17 @@ module.exports.serverOptions = {
     default: 3000,
     group: 'Server Options:',
   },
+  startProxy: {
+    type: 'boolean',
+    describe: 'Start a proxy server',
+    group: 'Server Options:',
+  },
+  proxyPort: {
+    type: 'number',
+    describe: 'Proxy server port',
+    default: 3010,
+    group: 'Server Options:',
+  },
   host: {
     type: 'string',
     describe: 'Development server host',

--- a/lib/commands/common-options.js
+++ b/lib/commands/common-options.js
@@ -8,6 +8,7 @@ module.exports.serverOptions = {
   startProxy: {
     type: 'boolean',
     describe: 'Start a proxy server',
+    default: false,
     group: 'Server Options:',
   },
   proxyPort: {

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -1,4 +1,6 @@
 const importLazy = require('import-lazy')(require);
+const childProcess = require('child_process');
+const path = require('path');
 
 const { contextMiddleware } = importLazy('../cli/context-middleware');
 const { stripesConfigMiddleware } = importLazy('../cli/stripes-config-middleware');
@@ -11,6 +13,15 @@ const server = importLazy('../server');
 // stripes-core does not currently support publicPath with the dev server
 const serveBuildOptions = Object.assign({}, buildOptions);
 delete serveBuildOptions.publicPath;
+
+function replaceArgvOkapiWithProxyURL(argv) {
+  const proxyURL = `http://localhost:${argv.proxyPort}`;
+  argv.okapi = proxyURL;
+
+  if (argv.stripesConfig?.okapi) {
+    argv.stripesConfig.okapi.url = proxyURL;
+  }
+}
 
 function serveCommand(argv) {
   const context = argv.context;
@@ -37,6 +48,13 @@ function serveCommand(argv) {
   if (argv.prod) {
     console.log('Production config not yet implemented with serve');
     return;
+  }
+
+  if (argv.startProxy) {
+    console.info('starting proxy');
+    childProcess.fork(path.resolve(context.cliRoot, './lib/run-proxy.js'), [argv.okapi, argv.proxyPort]);
+    // if we're using a proxy server - we need to pass the proxy host as okapi to Stripes platform
+    replaceArgvOkapiWithProxyURL(argv);
   }
 
   const platform = new StripesPlatform(argv.stripesConfig, context, argv);

--- a/lib/platform/tenant-config.js
+++ b/lib/platform/tenant-config.js
@@ -11,6 +11,7 @@ const defaultConfig = {
     showPerms: false,
     hasAllPerms: false,
     languages: ['en'],
+    useSecureTokens: false,
   },
   modules: {
   },

--- a/lib/platform/tenant-config.js
+++ b/lib/platform/tenant-config.js
@@ -11,7 +11,7 @@ const defaultConfig = {
     showPerms: false,
     hasAllPerms: false,
     languages: ['en'],
-    useSecureTokens: false,
+    useSecureTokens: true,
   },
   modules: {
   },

--- a/lib/run-proxy.js
+++ b/lib/run-proxy.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const { createProxyMiddleware } = require('http-proxy-middleware');
+
+const app = express();
+
+const OKAPI = process.argv[2];
+const PORT = process.argv[3];
+
+app.use(
+  '/',
+  createProxyMiddleware({
+    target: OKAPI,
+    changeOrigin: true,
+  }),
+);
+
+app.listen(PORT);

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "fs-extra": "^11.1.1",
     "get-stdin": "^6.0.0",
     "global-dirs": "^0.1.1",
+    "http-proxy-middleware": "^3.0.0",
     "import-lazy": "^3.1.0",
     "inquirer": "^8.2.0",
     "is-installed-globally": "^0.4.0",


### PR DESCRIPTION
## Description
After updates that involve using Cookies for authentication, developers could face issues that cookies wouldn’t be included in requests

Browsers refused to set cookies due to “SameSite=”Lax” attribute:
![image](https://github.com/folio-org/stripes-cli/assets/19309423/210efc9a-53e3-4c5e-a375-8ffebf740a49)
Since this is a browser limitation we can overcome this by setting up a local proxy server which would redirect requests to Okapi and back.

This server is included as part of stripes-cli, so that developers don't have to install any third-party software.
Added two new options to `serve` command:
- `--startProxy`
- `--proxyPort`

## Screenshots

https://github.com/folio-org/stripes-cli/assets/19309423/d1512568-55d6-43b9-b435-27b615675bcb


## Issues
[STCLI-246](https://folio-org.atlassian.net/browse/STCLI-246)