### PR TITLE
STCLI-247 overwrite CORS headers in proxy responses

### DIFF
--- a/doc/commands.md
+++ b/doc/commands.md
@@ -1132,6 +1132,7 @@ Option | Description | Type | Notes
 `--stripesConfig` | Stripes config JSON  | string | supports stdin
 `--tenant` | Specify a tenant ID | string |
 `--startProxy` | Start a local proxy server between the platform and okapi | boolean | default: false
+`--proxyHost` | Scheme and host name for the proxy server | string | default: http://localhost
 `--proxyPort` | Port number for the proxy server | number | default: 3010
 
 Examples:
@@ -1150,7 +1151,7 @@ $ stripes serve --existing-build output
 ```
 Serve a platform with a local proxy server that points to a remote okapi server:
 ```
-$ stripes serve --startProxy --proxyPort 3010 --okapi http://some-okapi-server.folio.org
+$ stripes serve --startProxy --proxyHost http://localhost --proxyPort 3010 --okapi http://some-okapi-server.folio.org
 ```
 Serve an app (in app context) with a mock backend server":
 ```

--- a/lib/commands/common-options.js
+++ b/lib/commands/common-options.js
@@ -11,6 +11,12 @@ module.exports.serverOptions = {
     default: false,
     group: 'Server Options:',
   },
+  proxyHost: {
+    type: 'string',
+    describe: 'Proxy scheme and host',
+    default: 'http://localhost',
+    group: 'Server Options:',
+  },
   proxyPort: {
     type: 'number',
     describe: 'Proxy server port',

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -15,11 +15,10 @@ const serveBuildOptions = Object.assign({}, buildOptions);
 delete serveBuildOptions.publicPath;
 
 function replaceArgvOkapiWithProxyURL(argv) {
-  const proxyURL = `http://localhost:${argv.proxyPort}`;
-  argv.okapi = proxyURL;
+  argv.okapi = `${argv.proxyHost}:${argv.proxyPort}`;
 
   if (argv.stripesConfig?.okapi) {
-    argv.stripesConfig.okapi.url = proxyURL;
+    argv.stripesConfig.okapi.url = argv.okapi;
   }
 }
 
@@ -52,7 +51,7 @@ function serveCommand(argv) {
 
   if (argv.startProxy) {
     console.info('starting proxy');
-    childProcess.fork(path.resolve(context.cliRoot, './lib/run-proxy.js'), [argv.okapi, argv.proxyPort, argv.port]);
+    childProcess.fork(path.resolve(context.cliRoot, './lib/run-proxy.js'), [argv.okapi, argv.port, argv.proxyHost, argv.proxyPort]);
     // if we're using a proxy server - we need to pass the proxy host as okapi to Stripes platform
     replaceArgvOkapiWithProxyURL(argv);
   }

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -52,7 +52,7 @@ function serveCommand(argv) {
 
   if (argv.startProxy) {
     console.info('starting proxy');
-    childProcess.fork(path.resolve(context.cliRoot, './lib/run-proxy.js'), [argv.okapi, argv.proxyPort]);
+    childProcess.fork(path.resolve(context.cliRoot, './lib/run-proxy.js'), [argv.okapi, argv.proxyPort, argv.port]);
     // if we're using a proxy server - we need to pass the proxy host as okapi to Stripes platform
     replaceArgvOkapiWithProxyURL(argv);
   }

--- a/lib/run-proxy.js
+++ b/lib/run-proxy.js
@@ -11,6 +11,11 @@ app.use(
   createProxyMiddleware({
     target: OKAPI,
     changeOrigin: true,
+    on: {
+      proxyRes: (proxyRes) => {
+        delete proxyRes.headers['Access-Control-Allow-Origin'];
+      },
+    },
   }),
 );
 

--- a/lib/run-proxy.js
+++ b/lib/run-proxy.js
@@ -4,8 +4,9 @@ const { createProxyMiddleware } = require('http-proxy-middleware');
 const app = express();
 
 const OKAPI = process.argv[2];
-const PROXY_PORT = process.argv[3];
-const PORT = process.argv[4];
+const PORT = process.argv[3];
+const PROXY_HOST = process.argv[4];
+const PROXY_PORT = process.argv[5];
 
 app.use(
   '/',
@@ -14,7 +15,7 @@ app.use(
     changeOrigin: true,
     on: {
       proxyRes: (proxyRes) => {
-        proxyRes.headers['Access-Control-Allow-Origin'] = `http://localhost:${PORT}`;
+        proxyRes.headers['Access-Control-Allow-Origin'] = `${PROXY_HOST}:${PORT}`;
         proxyRes.headers['Access-Control-Allow-Credentials'] = 'true';
       },
     },

--- a/lib/run-proxy.js
+++ b/lib/run-proxy.js
@@ -15,6 +15,7 @@ app.use(
     on: {
       proxyRes: (proxyRes) => {
         proxyRes.headers['Access-Control-Allow-Origin'] = `http://localhost:${PORT}`;
+        proxyRes.headers['Access-Control-Allow-Credentials'] = 'true';
       },
     },
   }),

--- a/lib/run-proxy.js
+++ b/lib/run-proxy.js
@@ -4,7 +4,8 @@ const { createProxyMiddleware } = require('http-proxy-middleware');
 const app = express();
 
 const OKAPI = process.argv[2];
-const PORT = process.argv[3];
+const PROXY_PORT = process.argv[3];
+const PORT = process.argv[4];
 
 app.use(
   '/',
@@ -13,10 +14,10 @@ app.use(
     changeOrigin: true,
     on: {
       proxyRes: (proxyRes) => {
-        delete proxyRes.headers['Access-Control-Allow-Origin'];
+        proxyRes.headers['Access-Control-Allow-Origin'] = `http://localhost:${PORT}`;
       },
     },
   }),
 );
 
-app.listen(PORT);
+app.listen(PROXY_PORT);


### PR DESCRIPTION
There are two features here:
1. provide new CLI option `--proxyUrl` to allow use of a hostname other than localhost, allowing the machine hosting the bundle to be accessed remotely (e.g. from a conference room, or by a colleague in another office, etc etc)
2. overwrite CORS headers between the proxy and browser, satisfying the browser that CORS requirements are being met (shhhhh) 

Details on Part 2: 

Overwrite the following CORS headers between the proxy and browser: 
```
Access-Control-Allow-Origin: http://localhost:${PORT}
Access-Control-Allow-Credentials: true
```

The ACAO value is commonly set to `*` for un-credentialed requests (i.e. those without cookies), but as [MDN docs for CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) notes:
> When responding to a [credentialed requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#requests_with_credentials) request, the server must specify an origin in the value of the `Access-Control-Allow-Origin` header, instead of specifying the “*” wildcard. Likewise, the ACAC value is commonly set to `""` for uncredentialed requests, but must be set to `true` to allow cookies to pass through. 

These CORS settings appear to have been in place before RTR was introduced, and may still be in place in some backend environments. Overriding these values in the local proxy is a prudent way to allow local development to continue while waiting for the backend settings to catch up. 

Refs [STCLI-247](https://folio-org.atlassian.net/browse/STCLI-247)