### PR TITLE
Use --proxyUrl to allow control over the scheme, host, and port

### DIFF
--- a/doc/commands.md
+++ b/doc/commands.md
@@ -1132,6 +1132,7 @@ Option | Description | Type | Notes
 `--stripesConfig` | Stripes config JSON  | string | supports stdin
 `--tenant` | Specify a tenant ID | string |
 `--startProxy` | Start a local proxy server between the platform and okapi | boolean | default: false
+`--proxyHost` | Scheme and host name for the proxy server | string | default: http://localhost
 `--proxyPort` | Port number for the proxy server | number | default: 3010
 
 Examples:
@@ -1150,7 +1151,7 @@ $ stripes serve --existing-build output
 ```
 Serve a platform with a local proxy server that points to a remote okapi server:
 ```
-$ stripes serve --startProxy --proxyPort 3010 --okapi http://some-okapi-server.folio.org
+$ stripes serve --startProxy --proxyHost http://localhost --proxyPort 3010 --okapi http://some-okapi-server.folio.org
 ```
 Serve an app (in app context) with a mock backend server":
 ```

--- a/lib/commands/common-options.js
+++ b/lib/commands/common-options.js
@@ -11,6 +11,12 @@ module.exports.serverOptions = {
     default: false,
     group: 'Server Options:',
   },
+  proxyHost: {
+    type: 'string',
+    describe: 'Proxy scheme and host',
+    default: 'http://localhost',
+    group: 'Server Options:',
+  },
   proxyPort: {
     type: 'number',
     describe: 'Proxy server port',

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -15,11 +15,10 @@ const serveBuildOptions = Object.assign({}, buildOptions);
 delete serveBuildOptions.publicPath;
 
 function replaceArgvOkapiWithProxyURL(argv) {
-  const proxyURL = `http://localhost:${argv.proxyPort}`;
-  argv.okapi = proxyURL;
+  argv.okapi = `${argv.proxyHost}:${argv.proxyPort}`;
 
   if (argv.stripesConfig?.okapi) {
-    argv.stripesConfig.okapi.url = proxyURL;
+    argv.stripesConfig.okapi.url = argv.okapi;
   }
 }
 
@@ -52,7 +51,7 @@ function serveCommand(argv) {
 
   if (argv.startProxy) {
     console.info('starting proxy');
-    childProcess.fork(path.resolve(context.cliRoot, './lib/run-proxy.js'), [argv.okapi, argv.proxyPort, argv.port]);
+    childProcess.fork(path.resolve(context.cliRoot, './lib/run-proxy.js'), [argv.okapi, argv.port, argv.proxyHost, argv.proxyPort]);
     // if we're using a proxy server - we need to pass the proxy host as okapi to Stripes platform
     replaceArgvOkapiWithProxyURL(argv);
   }

--- a/lib/run-proxy.js
+++ b/lib/run-proxy.js
@@ -4,8 +4,9 @@ const { createProxyMiddleware } = require('http-proxy-middleware');
 const app = express();
 
 const OKAPI = process.argv[2];
-const PROXY_PORT = process.argv[3];
-const PORT = process.argv[4];
+const PORT = process.argv[3];
+const PROXY_HOST = process.argv[4];
+const PROXY_PORT = process.argv[5];
 
 app.use(
   '/',
@@ -14,7 +15,7 @@ app.use(
     changeOrigin: true,
     on: {
       proxyRes: (proxyRes) => {
-        proxyRes.headers['Access-Control-Allow-Origin'] = `http://localhost:${PORT}`;
+        proxyRes.headers['Access-Control-Allow-Origin'] = `${PROXY_HOST}:${PORT}`;
         proxyRes.headers['Access-Control-Allow-Credentials'] = 'true';
       },
     },


### PR DESCRIPTION
Use case, per @kaladay: 

* This allows a workstation with a static IP to (a) serve as the proxy and (b) host the corresponding bundle for a third party, e.g. a demo machine in another room, a colleague in another office
