### PR TITLE
STCLI-251 GA: Omit publishing MD

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -13,4 +13,6 @@ jobs:
       jest-test-command: yarn run test
       sonar-sources: ./lib
       compile-translations: false
+      generate-module-descriptor: false
+      publish-module-descriptor: false
 


### PR DESCRIPTION
There is no module descriptor here.

Refs [STCLI-251](https://folio-org.atlassian.net/browse/STCLI-251), [STRIPES-938](https://folio-org.atlassian.net/browse/STRIPES-938)