### PR TITLE
STCLI-256 turn off StrictMode when running tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.3.0 IN PROGRESS
 
 * Prune STS headers, permitting local non-SSL access via proxy. Refs STCLI-248.
-* Turn of `<StrictMode>` when running tests. Refs STCLI-256.
+* Turn off `<StrictMode>` when running tests. Refs STCLI-256.
 
 ## [3.2.0](https://github.com/folio-org/stripes-cli/tree/v3.2.0) (2024-10-09)
 [Full Changelog](https://github.com/folio-org/stripes-cli/compare/v3.1.0...v3.2.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.3.0 IN PROGRESS
 
 * Prune STS headers, permitting local non-SSL access via proxy. Refs STCLI-248.
+* Turn of `<StrictMode>` when running tests. Refs STCLI-256.
 
 ## [3.2.0](https://github.com/folio-org/stripes-cli/tree/v3.2.0) (2024-10-09)
 [Full Changelog](https://github.com/folio-org/stripes-cli/compare/v3.1.0...v3.2.0)

--- a/lib/platform/tenant-config.js
+++ b/lib/platform/tenant-config.js
@@ -12,6 +12,10 @@ const defaultConfig = {
     hasAllPerms: false,
     languages: ['en'],
     useSecureTokens: true,
+
+    // run tests in production-mode
+    // <StrictMode> is intended for dev-only
+    disableStrictMode: true,
   },
   modules: {
   },


### PR DESCRIPTION
`<StrictMode>` is intended to be a development-only setting so it should be disabled when running tests. e.g. a component that fetches data on mount with `accumulate: true` would see that data duplicated.

Refs [STCLI-256](https://folio-org.atlassian.net/browse/STCLI-256)