### PR TITLE
STCLI-258 Check for `main` branch in `stripes platform pull` command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Prune STS headers, permitting local non-SSL access via proxy. Refs STCLI-248.
 * Turn off `<StrictMode>` when running tests. Refs STCLI-256.
+* Check for `main` branch in `stripes platform pull` command. Refs STCLI-258.
 
 ## [3.2.0](https://github.com/folio-org/stripes-cli/tree/v3.2.0) (2024-10-09)
 [Full Changelog](https://github.com/folio-org/stripes-cli/compare/v3.1.0...v3.2.0)

--- a/lib/commands/platform/pull.js
+++ b/lib/commands/platform/pull.js
@@ -22,8 +22,8 @@ function pullRepository(dir) {
         if (status.ahead) {
           reject(new Error('Branch contains committed changes to push.'));
         }
-        if (status.current !== 'master') {
-          reject(new Error(`Branch is not master. (${status.current})`));
+        if (status.current !== 'master' && status.current !== 'main') {
+          reject(new Error(`Branch is not master or main. (${status.current})`));
         }
         resolve(status);
       })


### PR DESCRIPTION
## Description
Since a few of UI modules are now using `main` instead of `master` branch we should update the pull command to check for it also.

## Issues
[STCLI-258](https://folio-org.atlassian.net/browse/STCLI-258)