### PR TITLE
STCLI-259 provide transpile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Change history for stripes-cli
 
-## 3.3.0 IN PROGRESS
+## 4.0.0 IN PROGRESS
 
 * Prune STS headers, permitting local non-SSL access via proxy. Refs STCLI-248.
 * Turn off `<StrictMode>` when running tests. Refs STCLI-256.
 * Check for `main` branch in `stripes platform pull` command. Refs STCLI-258.
+* **BREAKING** Correctly implment `transpile`. Refs STCLI-259.
 
 ## [3.2.0](https://github.com/folio-org/stripes-cli/tree/v3.2.0) (2024-10-09)
 [Full Changelog](https://github.com/folio-org/stripes-cli/compare/v3.1.0...v3.2.0)

--- a/lib/commands/transpile-babel.config.json
+++ b/lib/commands/transpile-babel.config.json
@@ -1,0 +1,22 @@
+{
+  "presets": [
+    ["@babel/preset-env", {
+      "targets": "> 0.25%, not dead",
+      "exclude": ["transform-dynamic-import"]
+    }],
+    ["@babel/preset-flow", { "all": true }],
+    ["@babel/preset-react", { "runtime": "automatic" }],
+    ["@babel/preset-typescript"]
+  ],
+  "plugins": [
+    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    ["@babel/plugin-transform-class-properties", { "loose": true }],
+    ["@babel/plugin-transform-private-methods", { "loose": true }],
+    ["@babel/plugin-transform-private-property-in-object", { "loose": true }],
+    "@babel/plugin-transform-export-namespace-from",
+    "@babel/plugin-proposal-function-sent",
+    "@babel/plugin-transform-numeric-separator",
+    "@babel/plugin-proposal-throw-expressions",
+    "@babel/plugin-syntax-import-meta"
+  ]
+}

--- a/lib/commands/transpile.js
+++ b/lib/commands/transpile.js
@@ -1,43 +1,42 @@
 const importLazy = require('import-lazy')(require);
+const path = require('node:path');
+const { spawn } = require('node:child_process');
 
 const { contextMiddleware } = importLazy('../cli/context-middleware');
-const StripesCore = importLazy('../cli/stripes-core');
-const StripesPlatform = importLazy('../platform/stripes-platform');
-const { stripesConfigFile } = importLazy('./common-options');
-const { processError, processStats } = importLazy('../webpack-common');
 
-let _stripesPlatform;
-let _stripesCore;
-
-// stripesPlatform and stripesCore overrides primarily used as injection for unit tests
-function stripesOverrides(stripesPlatform, stripesCore) {
-  _stripesPlatform = stripesPlatform;
-  _stripesCore = stripesCore;
-}
-
+/**
+ * transpile
+ * @param {object} argv arguments parsed by yargs
+ */
 function transpileCommand(argv) {
-  const context = argv.context;
   // Default transpile command to production env
   if (!process.env.NODE_ENV) {
     process.env.NODE_ENV = 'production';
   }
 
-  const platform = _stripesPlatform || new StripesPlatform(argv.stripesConfig, context, argv);
-  const webpackOverrides = [];
-
-  if (argv.analyze) {
-    const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin; // eslint-disable-line
-    webpackOverrides.push((config) => {
-      config.plugins.push(new BundleAnalyzerPlugin());
-      return config;
-    });
-  }
-
   console.info('Transpiling...');
-  const stripes = _stripesCore || new StripesCore(context, platform.aliases);
-  stripes.api.transpile(Object.assign({}, argv, { webpackOverrides }))
-    .then(processStats)
-    .catch(processError);
+
+  const transpile = spawn('babel', [
+    argv.files,
+    '--ignore', `dist,node_modules,.storybook,karma.conf.js,jest.config.js,test,tests,${argv.files}/**/tests,${argv.files}/**/*.test.js`,
+    '-d', 'dist', // output directory
+    '-s',         // include sourcemaps
+    '-D',         // copy over non-compilable files
+    '--delete-dir-on-start',  // clean
+    '--config-file', `${__dirname}${path.sep}transpile-babel.config.json`,
+  ]);
+
+  transpile.stdout.on('data', (data) => {
+    console.log(`${data}`);
+  });
+
+  transpile.stderr.on('data', (data) => {
+    console.error(`stderr: ${data}`);
+  });
+
+  // transpile.on('close', (code) => {
+  //   console.log(`child process exited with code ${code}`);
+  // });
 }
 
 module.exports = {
@@ -48,13 +47,14 @@ module.exports = {
       .middleware([
         contextMiddleware(),
       ])
-      .positional('configFile', stripesConfigFile.configFile)
-      .option('analyze', {
-        describe: 'Run the Webpack Bundle Analyzer after build (launches in browser)',
-        type: 'boolean',
-      })
-      .example('$0 transpile', 'Transpile a module');
+      .example('$0 transpile --files <path>', 'Transpile files in <path>');
+    yargs.option('files', {
+      describe: 'Path to directory containing files to transpile',
+      type: 'string',
+      default: './src',
+    });
+
+    return yargs;
   },
   handler: transpileCommand,
-  stripesOverrides,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-cli",
-  "version": "3.3.0",
+  "version": "4.0.0",
   "description": "Stripes Command Line Interface",
   "repository": "https://github.com/folio-org/stripes-cli",
   "publishConfig": {
@@ -22,6 +22,23 @@
     "docs": "node ./lib/doc/generator"
   },
   "dependencies": {
+    "@babel/cli": "^7.26.4",
+    "@babel/core": "^7.9.0",
+    "@babel/plugin-proposal-decorators": "^7.0.0",
+    "@babel/plugin-proposal-function-sent": "^7.0.0",
+    "@babel/plugin-proposal-throw-expressions": "^7.0.0",
+    "@babel/plugin-syntax-import-meta": "^7.0.0",
+    "@babel/plugin-transform-class-properties": "^7.0.0",
+    "@babel/plugin-transform-dynamic-import": "^7.25.9",
+    "@babel/plugin-transform-export-namespace-from": "^7.0.0",
+    "@babel/plugin-transform-numeric-separator": "^7.0.0",
+    "@babel/plugin-transform-private-methods": "^7.18.6",
+    "@babel/plugin-transform-private-property-in-object": "^7.21.0",
+    "@babel/preset-env": "^7.26.0",
+    "@babel/preset-flow": "^7.25.9",
+    "@babel/preset-react": "^7.26.3",
+    "@babel/preset-typescript": "^7.26.0",
+    "@babel/register": "^7.25.9",
     "@folio/stripes-testing": "^3.0.0",
     "@folio/stripes-webpack": "^5.2.0",
     "@formatjs/cli": "^6.1.3",


### PR DESCRIPTION
Replace the `transpile` command implmented in #259 (STCLI-224), which transpiled and bundled with help from stripes-cli, with one that only conducts transpilation.

```
yarn stripes transpile
yarn stripes transpile --path ./lib
```

The default `path` is `./src`. Files are transpiled into `./dist`. Sourcemaps are included. Non-compilable files (e.g. `.css`) are copied into the destination directory.

All dependencies and babel config files are included locally. The intent is to provide a canonical service, much as stripes-webpack has in the past, so the packages using this service do not have to worry about managing dependencies or config files.

The babel config is contained in
`./lib/commands/transpile-babel.config.json`:
```
{
  "presets": [
    ["@babel/preset-env", {
      "targets": "> 0.25%, not dead",
      // preset-env will transform dynamic exports, but we want
      // to let webpack handle those
      "exclude": ["transform-dynamic-import"]
    }],
    ["@babel/preset-flow", { "all": true }],
    ["@babel/preset-react", { "runtime": "automatic" }],
    ["@babel/preset-typescript"]
  ],
  "plugins": [
    ["@babel/plugin-proposal-decorators", { "legacy": true }],
    // when building a platform directly, i.e. outside a workspace,
    // babel complains loudly and repeatedly that when these modules are enabled:
    // * @babel/plugin-proposal-class-properties,
    // * @babel/plugin-proposal-private-methods and
    // * @babel/plugin-proposal-private-property-in-object
    // the "loose" option must be the same for all three.
    // but @babel/preset-env sets it to false for ...private-methods.
    // overriding it here silences the complaint. STRWEB-12
    ["@babel/plugin-transform-class-properties", { "loose": true }],
    ["@babel/plugin-transform-private-methods", { "loose": true }],
    ["@babel/plugin-transform-private-property-in-object", { "loose": true }],
    "@babel/plugin-transform-export-namespace-from",
    "@babel/plugin-proposal-function-sent",
    "@babel/plugin-transform-numeric-separator",
    "@babel/plugin-proposal-throw-expressions",
    "@babel/plugin-syntax-import-meta"
  ]
}
```

Refs [STCLI-259](https://folio-org.atlassian.net/browse/STCLI-259)