### PR TITLE
bump @folio/eslint-config-stripes to v8.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Turn off `<StrictMode>` when running tests. Refs STCLI-256.
 * Check for `main` branch in `stripes platform pull` command. Refs STCLI-258.
 * *BREAKING* bump `@folio/stripes-webpack` to `6.0.0`.
+* *BREAKING* bump `@folio/eslint-config-stripes` to `8.0.0`.
 
 ## [3.2.0](https://github.com/folio-org/stripes-cli/tree/v3.2.0) (2024-10-09)
 [Full Changelog](https://github.com/folio-org/stripes-cli/compare/v3.1.0...v3.2.0)

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "dependencies": {
     "@folio/stripes-testing": "^3.0.0",
     "@folio/stripes-webpack": "^6.0.0",
-    "@formatjs/cli": "^6.1.3",
-    "@formatjs/cli-lib": "^6.1.3",
+    "@formatjs/cli": "^6.6.0",
+    "@formatjs/cli-lib": "^7.3.0",
     "@octokit/rest": "^19.0.7",
     "babel-plugin-istanbul": "^6.0.0",
     "configstore": "^3.1.1",
@@ -74,7 +74,7 @@
     "yargs": "^17.3.1"
   },
   "devDependencies": {
-    "@folio/eslint-config-stripes": "^7.0.0",
+    "@folio/eslint-config-stripes": "^8.0.0",
     "chai": "^4.1.2",
     "colors": "1.4.0",
     "eslint": "^7.32.0",


### PR DESCRIPTION
* Upgrade `@folio/eslint-config-stripes` to `v8.0.0` in order to provide consistent dependencies.