### PR TITLE
STCLI-262 upgrade @formatjs/cli packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Check for `main` branch in `stripes platform pull` command. Refs STCLI-258.
 * *BREAKING* bump `@folio/stripes-webpack` to `6.0.0`.
 * *BREAKING* bump `NodeJS` to `v20`. Refs STCLI-260.
+* Bump `@formatjs/cli` and `@formatjs/cli-lib` to their latest versions. Refs STCLI-262.
 
 ## [3.2.0](https://github.com/folio-org/stripes-cli/tree/v3.2.0) (2024-10-09)
 [Full Changelog](https://github.com/folio-org/stripes-cli/compare/v3.1.0...v3.2.0)

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "dependencies": {
     "@folio/stripes-testing": "^3.0.0",
     "@folio/stripes-webpack": "^6.0.0",
-    "@formatjs/cli": "^6.1.3",
-    "@formatjs/cli-lib": "^6.1.3",
+    "@formatjs/cli": "^6.6.0",
+    "@formatjs/cli-lib": "^7.3.0",
     "@octokit/rest": "^19.0.7",
     "babel-plugin-istanbul": "^6.0.0",
     "configstore": "^3.1.1",


### PR DESCRIPTION
* `@formatjs/cli` to `^6.6.0`
* `@formatjs/cli-lib` to `^7.3.0`

Refs [STCLI-262](https://folio-org.atlassian.net/browse/STCLI-262)