### PR TITLE
Revert "STCLI-262 upgrade @formatjs/cli packages (#373)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 * Check for `main` branch in `stripes platform pull` command. Refs STCLI-258.
 * *BREAKING* bump `@folio/stripes-webpack` to `6.0.0`.
 * *BREAKING* bump `NodeJS` to `v20`. Refs STCLI-260.
-* Bump `@formatjs/cli` and `@formatjs/cli-lib` to their latest versions. Refs STCLI-262.
 * *BREAKING* bump `@folio/eslint-config-stripes` to `8.0.0`.
 
 ## [3.2.0](https://github.com/folio-org/stripes-cli/tree/v3.2.0) (2024-10-09)

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "dependencies": {
     "@folio/stripes-testing": "^3.0.0",
     "@folio/stripes-webpack": "^6.0.0",
-    "@formatjs/cli": "^6.6.0",
-    "@formatjs/cli-lib": "^7.3.0",
+    "@formatjs/cli": "^6.1.3",
+    "@formatjs/cli-lib": "^6.1.3",
     "@octokit/rest": "^19.0.7",
     "babel-plugin-istanbul": "^6.0.0",
     "configstore": "^3.1.1",


### PR DESCRIPTION
This reverts commit 4216bc7e3467f7dc68f17370664ee11eda759db1 (PR #373).

Not sure how I missed that v7 converts to ESM