### PR TITLE
Revert "STCLI-260 bump NodeJS to v20 (#371)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 * Turn off `<StrictMode>` when running tests. Refs STCLI-256.
 * Check for `main` branch in `stripes platform pull` command. Refs STCLI-258.
 * *BREAKING* bump `@folio/stripes-webpack` to `6.0.0`.
-* *BREAKING* bump `NodeJS` to `v20`. Refs STCLI-260.
 * *BREAKING* bump `@folio/eslint-config-stripes` to `8.0.0`.
 
 ## [3.2.0](https://github.com/folio-org/stripes-cli/tree/v3.2.0) (2024-10-09)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=14.0.0"
   },
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
This reverts commit 69b4aef7df3204731eb8dd464162b23a68147096.

The Jenkins nodes where we build platform-complete don't yet have NodeJS v20 and we don't know when it will be available. In the interest of making other changes (which, AFAIK, do directly not rely on NodeJS v20) available ASAP, we are reverting this change until our build nodes can support it.

Refs [STCLI-260](https://folio-org.atlassian.net/browse/STCLI-260)