### PR TITLE
STCLI-264 bump @folio/stripes-webpack to ~5.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-cli
 
+## IN PROGRESS
+
+* Bump `@folio/stripes-webpack` to `5.1.1`. Refs STCLI-264.
+
 ## [3.1.0](https://github.com/folio-org/stripes-cli/tree/v3.1.0) (2024-03-12)
 [Full Changelog](https://github.com/folio-org/stripes-cli/compare/v3.0.0...v3.1.0)
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@folio/stripes-testing": "^3.0.0",
-    "@folio/stripes-webpack": "^5.1.0",
+    "@folio/stripes-webpack": "~5.1.1",
     "@formatjs/cli": "^6.1.3",
     "@formatjs/cli-lib": "^6.1.3",
     "@octokit/rest": "^19.0.7",


### PR DESCRIPTION
Bump `@folio/stripes-webpack` to `~5.1.1`.

Refs [STCLI-264](https://folio-org.atlassian.net/browse/STCLI-264)