### PR TITLE
STCLI-263 bump @folio/stripes-webpack to ~5.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-cli
 
+## IN PROGRESS
+
+* Bump `@folio/stripes-webpack` to `^5.2.1`. Refs STCLI-263.
+
 ## [3.2.1](https://github.com/folio-org/stripes-cli/tree/v3.2.1) (2024-11-25)
 [Full Changelog](https://github.com/folio-org/stripes-cli/compare/v3.2.0...v3.2.1)
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@folio/stripes-testing": "^3.0.0",
-    "@folio/stripes-webpack": "^5.2.0",
+    "@folio/stripes-webpack": "~5.2.1",
     "@formatjs/cli": "^6.1.3",
     "@formatjs/cli-lib": "^6.1.3",
     "@octokit/rest": "^19.0.7",


### PR DESCRIPTION
Bump `@folio/stripes-webpack` to `~5.2.1`.

Refs [STCLI-263](https://folio-org.atlassian.net/browse/STCLI-263)