### PR TITLE
STCLI-266 loose GA workflow dependency

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   ui:
-    uses: folio-org/.github/.github/workflows/ui.yml@v1.1
+    uses: folio-org/.github/.github/workflows/ui.yml@v1
     secrets: inherit
     with:
       jest-enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Check for `main` branch in `stripes platform pull` command. Refs STCLI-258.
 * *BREAKING* bump `@folio/stripes-webpack` to `6.0.0`.
 * *BREAKING* bump `@folio/eslint-config-stripes` to `8.0.0`.
+* Loosen GA workflow dependency to `@1` for `^1.0.0` compatibility. Refs STCLI-266.
 
 ## [3.2.0](https://github.com/folio-org/stripes-cli/tree/v3.2.0) (2024-10-09)
 [Full Changelog](https://github.com/folio-org/stripes-cli/compare/v3.1.0...v3.2.0)


### PR DESCRIPTION
Loosen GA workflow dependency to `@1`. This allows us to use a version that avoids trying to check the validity of a non-existent module descriptor.

Refs [STCLI-266](https://folio-org.atlassian.net/browse/STCLI-266)