### PR TITLE
Added a `warningUndoChangesAndCheckoutMain` option to pull command

### DIFF
--- a/lib/commands/common-options.js
+++ b/lib/commands/common-options.js
@@ -171,3 +171,12 @@ module.exports.fileOptions = {
     describe: 'File containing JSON data',
   },
 };
+
+module.exports.pullOptions = {
+  warningUndoChangesAndCheckoutMain: {
+    type: 'boolean',
+    describe: 'Undo all uncommited changes and checkout main repo branch',
+    default: false,
+    group: 'Pull options:',
+  },
+};

--- a/lib/commands/platform/pull.js
+++ b/lib/commands/platform/pull.js
@@ -4,18 +4,32 @@ const { contextMiddleware } = importLazy('../../cli/context-middleware');
 const simpleGit = importLazy('simple-git');
 const DevelopmentEnvironment = importLazy('../../environment/development');
 
+const { pullOptions } = require('../common-options');
+
 function isClean(status) {
   const check = ['conflicted', 'created', 'deleted', 'modified', 'renamed'];
   return check.reduce((sum, name) => sum + status[name].length, 0) === 0;
 }
 
-function pullRepository(dir) {
+function pullRepository(dir, undoChangesAndCheckoutMain) {
   const git = simpleGit(dir);
 
   // Rejects if repo is not is suitable for pulling
   const okToPull = () => new Promise((resolve, reject) => {
     git.status()
-      .then((status) => {
+      .then(async (status) => {
+        if (undoChangesAndCheckoutMain) {
+          await git.raw('add', '-A'); // add all changes, including new files, deleted files so they are tracked by git
+          await git.raw('reset', '--hard', 'HEAD'); // and undo them all muahahaha ψ(｀∇´)ψ
+          try {
+            await git.checkout('main');
+          } catch (e) {} // if we can't checkout main - then ignore the error and checkout master
+          
+          await git.checkout('master');
+
+          return resolve(status);
+        }
+
         if (!isClean(status)) {
           reject(new Error('Branch contains changes.'));
         }
@@ -85,7 +99,7 @@ function pullCommand(argv) {
   return new Promise((resolve) => {
     let pulls;
     moduleDirs.forEach((dir) => {
-      pulls = pulls ? pulls.then(() => pullRepository(dir)) : pullRepository(dir);
+      pulls = pulls ? pulls.then(() => pullRepository(dir, argv.warningUndoChangesAndCheckoutMain)) : pullRepository(dir, argv.warningUndoChangesAndCheckoutMain);
     });
 
     pulls.then(() => {
@@ -103,6 +117,7 @@ module.exports = {
       .middleware([
         contextMiddleware(),
       ])
+      .options(Object.assign({}), pullOptions)
       .example('$0 platform pull', 'Pull all clean repositories including aliases');
     return yargs;
   },


### PR DESCRIPTION
## Description
Added a new `warningUndoChangesAndCheckoutMain` to `stripes platform pull` command to undo local changes and switch to master or main branch.
Personally, I have many repositories in my local platform and I often don't switch to main branch when I'm done with some work. This makes it cumbersome to execute the `pull` command because I need to manually go to each repo and undo changes/checkout main branches. This command can make it much easier to have the platform up-to-date

## Screenshots

https://github.com/user-attachments/assets/91492fd1-61c4-4409-a613-a9187660adac

