### PR TITLE
STCLI-267 pin webpack to v5.98.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * *BREAKING* bump `@folio/stripes-webpack` to `6.0.0`.
 * *BREAKING* bump `@folio/eslint-config-stripes` to `8.0.0`.
 * Loosen GA workflow dependency to `@1` for `^1.0.0` compatibility. Refs STCLI-266.
+* Pin `webpack` to `~5.98.0` to avoid buggy behavior in `5.99`. STCLI-267.
 
 ## [3.2.0](https://github.com/folio-org/stripes-cli/tree/v3.2.0) (2024-10-09)
 [Full Changelog](https://github.com/folio-org/stripes-cli/compare/v3.1.0...v3.2.0)

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "supports-color": "^4.5.0",
     "tough-cookie": "^4.1.3",
     "update-notifier": "^6.0.2",
-    "webpack": "^5.80.0",
+    "webpack": "~5.98.0",
     "webpack-bundle-analyzer": "^4.4.2",
     "yargs": "^17.3.1"
   },


### PR DESCRIPTION
`webpack` `v5.99.0` brought features like checking for dead flow-control statements and, the ability to generate custom error content, and improved support for `import.meta.url`. Yay! Unfortunately, it also came with https://github.com/webpack/webpack/issues/19394, which generates errors in tests like
```
ReferenceError: globals is not defined
  at converge (/var/folders/s8/jb_phxyn5vvcrx61_6f1qkn80000gn/T/_karma_webpack_239682/commons.js:118059:24)
  at converge.next (<anonymous>)
```

We'll unlock as soon as that's resolved.

Refs [STCLI-267](https://folio-org.atlassian.net/issues/STCLI-267)