### PR TITLE
STCLI-268 bump webpack to ^5.99.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * *BREAKING* bump `@folio/stripes-webpack` to `6.0.0`.
 * *BREAKING* bump `@folio/eslint-config-stripes` to `8.0.0`.
 * Loosen GA workflow dependency to `@1` for `^1.0.0` compatibility. Refs STCLI-266.
+* Boost `webpack` to `^5.99.3` to avoid buggy behavior in `5.99.0`. STCLI-268.
 
 ## [3.2.0](https://github.com/folio-org/stripes-cli/tree/v3.2.0) (2024-10-09)
 [Full Changelog](https://github.com/folio-org/stripes-cli/compare/v3.1.0...v3.2.0)

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "supports-color": "^4.5.0",
     "tough-cookie": "^4.1.3",
     "update-notifier": "^6.0.2",
-    "webpack": "^5.80.0",
+    "webpack": "^5.99.3",
     "webpack-bundle-analyzer": "^4.4.2",
     "yargs": "^17.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "supports-color": "^4.5.0",
     "tough-cookie": "^4.1.3",
     "update-notifier": "^6.0.2",
-    "webpack": "^5.99.3",
+    "webpack": "^5.99.6",
     "webpack-bundle-analyzer": "^4.4.2",
     "yargs": "^17.3.1"
   },


### PR DESCRIPTION
Bump `webpack` to `^5.99.3` to avoid hiccups in the early `5.99.x` releases, e.g. https://github.com/webpack/webpack/issues/19394. Replaces PR #386.

Refs [STCLI-268](https://folio-org.atlassian.net/browse/STCLI-268)