### PR TITLE
fix: Octokit usage

### DIFF
--- a/lib/environment/inventory.js
+++ b/lib/environment/inventory.js
@@ -1,6 +1,6 @@
 const fs = require('fs-extra');
 const path = require('path');
-const { Octokit } = require('@octokit/rest');
+//const { Octokit } = require('@octokit/rest');
 
 const MODULE_CACHE_FILE = '/inventory.json';
 
@@ -32,7 +32,10 @@ function readModules() {
 }
 
 async function fetchAndStoreModules() {
+  const { Octokit } = await import('@octokit/rest');
+
   const octokit = new Octokit();
+
   const repos = { apps: [], libs: [], other: [], platforms: [], plugins: [] };
   const options = octokit.repos.listForOrg.endpoint.merge({ org: 'folio-org', type: 'public' });
   const data = await octokit.paginate(options);

--- a/lib/environment/inventory.js
+++ b/lib/environment/inventory.js
@@ -1,6 +1,5 @@
 const fs = require('fs-extra');
 const path = require('path');
-//const { Octokit } = require('@octokit/rest');
 
 const MODULE_CACHE_FILE = '/inventory.json';
 


### PR DESCRIPTION
Octokit is now an ESM module as of v21.0.0. stripes-cli has updated to v22 as of [this PR](https://github.com/folio-org/stripes-cli/pull/395)

Brings the import into ESM patterns