### PR TITLE
STRCLI-285 Decouple from yarn classic

### DIFF
--- a/lib/cli/global-dirs.js
+++ b/lib/cli/global-dirs.js
@@ -10,7 +10,8 @@ function isYarnVersion(version) {
     logger.log('Yarn version', yarnVersion);
     return semver.satisfies(yarnVersion, version);
   } catch (err) {
-    logger.log('Unable to determine Yarn version.', err);
+    const logError = logger?.error ? logger.error : console.error;
+    logError('Unable to determine Yarn version.', err?.message ? err.message : err);
     return false;
   }
 }

--- a/lib/cli/global-dirs.js
+++ b/lib/cli/global-dirs.js
@@ -10,7 +10,7 @@ function isYarnVersion(version) {
     logger.log('Yarn version', yarnVersion);
     return semver.satisfies(yarnVersion, version);
   } catch (err) {
-    logger.error('Unable to determine Yarn version.', err);
+    logger.log('Unable to determine Yarn version.', err);
     return false;
   }
 }

--- a/lib/cli/stripes-core.js
+++ b/lib/cli/stripes-core.js
@@ -58,9 +58,9 @@ module.exports = class StripesCore {
   }
 
   getCoreModulePath(moduleId) {
-    const coreModulePath = (this.corePath === this.coreAlias)
-      ? path.join(this.corePath, moduleId)
-      : resolveFrom(this.corePath, `@folio/stripes-webpack/${moduleId}`);
+    const coreModulePath = (this.corePath.includes('node_modules'))
+      ? resolveFrom(this.corePath, `@folio/stripes-webpack/${moduleId}`)
+      : path.join(this.corePath, moduleId);
     return coreModulePath;
   }
 

--- a/lib/package-manager.js
+++ b/lib/package-manager.js
@@ -1,0 +1,76 @@
+const childProcess = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+function hasCommand(cmd) {
+  try {
+    const v = childProcess.execSync(`${cmd} --version`, { encoding: 'utf8' }).trim();
+    // simple check that command exists and returns something
+    return !!v;
+  } catch (e) {
+    return false;
+  }
+}
+
+function detect(projectDir) {
+  // Env override
+  const env = process.env.STRIPES_PKG_MANAGER;
+  if (env) return env;
+
+  // Prefer pnpm if a lockfile exists nearby
+  try {
+    const pnpmLock = path.join(projectDir || process.cwd(), 'pnpm-lock.yaml');
+    if (fs.existsSync(pnpmLock) && hasCommand('pnpm')) return 'pnpm';
+  } catch (e) {
+    // ignore
+  }
+
+  if (hasCommand('pnpm')) return 'pnpm';
+  if (hasCommand('yarn')) return 'yarn';
+  if (hasCommand('npm')) return 'npm';
+
+  // default to npm if nothing else
+  return 'npm';
+}
+
+function execCmd(cmd, args, options) {
+  return new Promise((resolve, reject) => {
+    const full = `${cmd} ${args.join(' ')}`.trim();
+    const p = childProcess.exec(full, options, (error) => {
+      if (error) return reject(error);
+      resolve({ isInstalled: true, appDir: options && options.cwd });
+    });
+    if (p && p.stdout) p.stdout.on('data', d => console.log(`  ${d.toString().trim()}`));
+    if (p && p.stderr) p.stderr.on('data', d => console.error(`  ${d.toString().trim()}`));
+  });
+}
+
+function install(projectDir) {
+  const pm = detect(projectDir);
+  console.log(`Using package manager: ${pm}`);
+  if (pm === 'pnpm') return execCmd('pnpm', ['install', '--frozen-lockfile'], { cwd: projectDir });
+  if (pm === 'yarn') return execCmd('yarn', [], { cwd: projectDir });
+  return execCmd('npm', ['install'], { cwd: projectDir });
+}
+
+function add(projectDir, packageName, isDev) {
+  const pm = detect(projectDir);
+  console.log(`Using package manager: ${pm}`);
+  const pkgs = [].concat(packageName).join(' ');
+  if (pm === 'pnpm') {
+    const flag = isDev ? ['-D'] : [];
+    return execCmd('pnpm', ['add'].concat(flag).concat([pkgs]), { cwd: projectDir });
+  }
+  if (pm === 'yarn') {
+    const flag = isDev ? '--dev' : '';
+    return execCmd('yarn', ['add', flag, pkgs].filter(Boolean), { cwd: projectDir });
+  }
+  const flag = isDev ? ['--save-dev'] : ['--save'];
+  return execCmd('npm', ['install'].concat(flag).concat([pkgs]), { cwd: projectDir });
+}
+
+module.exports = {
+  detect,
+  install,
+  add,
+};

--- a/lib/package-manager.js
+++ b/lib/package-manager.js
@@ -22,7 +22,7 @@ function detect(projectDir) {
     const pnpmLock = path.join(projectDir || process.cwd(), 'pnpm-lock.yaml');
     if (fs.existsSync(pnpmLock) && hasCommand('pnpm')) return 'pnpm';
   } catch (e) {
-    throw new Error('There was an error in stripes-cli initialization: Unable to detect package manager.');
+    throw new Error('There was an error in stripes-cli initialization: Unable to detect package manager.', { cause: e });
   }
 
   if (hasCommand('pnpm')) return 'pnpm';

--- a/lib/package-manager.js
+++ b/lib/package-manager.js
@@ -1,6 +1,6 @@
-const childProcess = require('child_process');
-const path = require('path');
-const fs = require('fs');
+const childProcess = require('node:child_process');
+const path = require('node:path');
+const fs = require('node:fs');
 
 function hasCommand(cmd) {
   try {
@@ -8,7 +8,7 @@ function hasCommand(cmd) {
     // simple check that command exists and returns something
     return !!v;
   } catch (e) {
-    return false;
+    throw new Error(`There was an error in stripes-cli initialization: Command not found - ${cmd}`);
   }
 }
 
@@ -22,7 +22,7 @@ function detect(projectDir) {
     const pnpmLock = path.join(projectDir || process.cwd(), 'pnpm-lock.yaml');
     if (fs.existsSync(pnpmLock) && hasCommand('pnpm')) return 'pnpm';
   } catch (e) {
-    // ignore
+    throw new Error('There was an error in stripes-cli initialization: Unable to detect package manager.');
   }
 
   if (hasCommand('pnpm')) return 'pnpm';
@@ -38,17 +38,18 @@ function execCmd(cmd, args, options) {
     const full = `${cmd} ${args.join(' ')}`.trim();
     const p = childProcess.exec(full, options, (error) => {
       if (error) return reject(error);
-      resolve({ isInstalled: true, appDir: options && options.cwd });
+      resolve({ isInstalled: true, appDir: options?.cwd });
+      return undefined;
     });
-    if (p && p.stdout) p.stdout.on('data', d => console.log(`  ${d.toString().trim()}`));
-    if (p && p.stderr) p.stderr.on('data', d => console.error(`  ${d.toString().trim()}`));
+    if (p?.stdout) p.stdout.on('data', d => console.log(`  ${d.toString().trim()}`));
+    if (p?.stderr) p.stderr.on('data', d => console.error(`  ${d.toString().trim()}`));
   });
 }
 
 function install(projectDir) {
   const pm = detect(projectDir);
   console.log(`Using package manager: ${pm}`);
-  if (pm === 'pnpm') return execCmd('pnpm', ['install', '--frozen-lockfile'], { cwd: projectDir });
+  if (pm === 'pnpm') return execCmd('pnpm', ['install'], { cwd: projectDir });
   if (pm === 'yarn') return execCmd('yarn', [], { cwd: projectDir });
   return execCmd('npm', ['install'], { cwd: projectDir });
 }
@@ -56,7 +57,7 @@ function install(projectDir) {
 function add(projectDir, packageName, isDev) {
   const pm = detect(projectDir);
   console.log(`Using package manager: ${pm}`);
-  const pkgs = [].concat(packageName).join(' ');
+  const pkgs = packageName.flat().join(' ');
   if (pm === 'pnpm') {
     const flag = isDev ? ['-D'] : [];
     return execCmd('pnpm', ['add'].concat(flag).concat([pkgs]), { cwd: projectDir });

--- a/lib/package-manager.js
+++ b/lib/package-manager.js
@@ -8,7 +8,7 @@ function hasCommand(cmd) {
     // simple check that command exists and returns something
     return !!v;
   } catch (e) {
-    throw new Error(`There was an error in stripes-cli initialization: Command not found - ${cmd}`);
+    throw new Error(`There was an error in stripes-cli initialization: Command not found - ${cmd}`, { cause: e });
   }
 }
 

--- a/lib/yarn.js
+++ b/lib/yarn.js
@@ -1,53 +1,8 @@
-const childProcess = require('child_process');
-
-function runYarn(options) {
-  return new Promise((resolve, reject) => {
-    const installProcess = childProcess.exec('yarn', options, (error) => {
-      if (error) {
-        reject(error);
-        return;
-      }
-      resolve({ isInstalled: true, appDir: options.cwd });
-    });
-    installProcess.stdout.on('data', data => console.log(`  ${data.trim()}`));
-  });
-}
-
-function yarnAdd(packageName, isDevDep, options) {
-  const pkgs = [].concat(packageName).join(' ');
-  const flag = isDevDep ? '--dev' : '';
-
-  return new Promise((resolve, reject) => {
-    const installProcess = childProcess.exec(`yarn add ${flag} ${pkgs}`, options, (error) => {
-      if (error) {
-        reject(error);
-        return;
-      }
-      resolve({ isInstalled: true, appDir: options.cwd });
-    });
-    installProcess.stdout.on('data', data => console.log(`  ${data.trim()}`));
-  });
-}
-
-// Above method does not capture full yarn output, but is a lot quieter
-// TODO: Offer option to toggle between the two
-
-// function runYarn(options) {
-//   options.stdio = 'inherit';
-//   return new Promise((resolve, reject) => {
-//     childProcess.spawn('yarn', [], options)
-//       .on('exit', (error) => {
-//         if (error) {
-//           reject(error);
-//         }
-//         resolve({ isInstalled: true, appDir: options.cwd });
-//       });
-//   });
-// }
+const packageManager = require('./package-manager');
 
 function install(projectDir) {
   console.log(` Directory "${projectDir}"`);
-  return runYarn({ cwd: projectDir })
+  return packageManager.install(projectDir)
     .catch((err) => {
       console.error('Something went wrong while attempting to use Yarn.');
       console.info(err);
@@ -56,9 +11,9 @@ function install(projectDir) {
 
 function add(projectDir, packageName, isDev) {
   console.log(` Directory "${projectDir}"`);
-  return yarnAdd(packageName, isDev, { cwd: projectDir })
+  return packageManager.add(projectDir, packageName, isDev)
     .catch((err) => {
-      console.error('Something went wrong while attempting to use Yarn.');
+      console.error('Something went wrong while attempting to add package via package manager.');
       console.info(err);
     });
 }


### PR DESCRIPTION
## [STCLI-285](https://folio-org.atlassian.net/browse/STCLI-285)
This PR moves stripes-cli over its initial hump of compatibility with anything outside of yarn classic, enabling it to work on systems where `yarn` is not installed.
Some functionality of stripes-cli -
- app create
- app bigtest

depend on yarn commands, specifically - this takes that logic and generalizes it - so that migration can happen in an opt-in manner. At least this portion of the tooling will be compatible with `pnpm`, `npm` or `yarn`.

